### PR TITLE
GUI(ruleEditor): Update default selection and reorder rule types

### DIFF
--- a/addon/globalPlugins/webAccess/gui/ruleEditor.py
+++ b/addon/globalPlugins/webAccess/gui/ruleEditor.py
@@ -208,6 +208,7 @@ class GeneralPanel(ContextualSettingsPanel):
 
 		self.ruleName.Value = data.get("name", "")
 		self.commentText.Value = data.get("comment", "")
+		self.onTypeChange(None)
 		self.refreshSummary()
 
 	def updateData(self, data=None):

--- a/addon/globalPlugins/webAccess/gui/ruleEditor.py
+++ b/addon/globalPlugins/webAccess/gui/ruleEditor.py
@@ -204,7 +204,7 @@ class GeneralPanel(ContextualSettingsPanel):
 					self.ruleType.SetSelection(index)
 					break
 		else:
-			self.ruleType.SetSelection(-1)
+			self.ruleType.SetSelection(0)
 
 		self.ruleName.Value = data.get("name", "")
 		self.commentText.Value = data.get("comment", "")

--- a/addon/globalPlugins/webAccess/ruleHandler/ruleTypes.py
+++ b/addon/globalPlugins/webAccess/ruleHandler/ruleTypes.py
@@ -33,24 +33,24 @@ addonHandler.initTranslation()
 
 
 MARKER = "marker"
-PAGE_TITLE_1 = "pageTitle1"
-PAGE_TITLE_2 = "pageTitle2"
+ZONE = "zone"
 PAGE_TYPE = "pageType"
 PARENT = "parent"
-ZONE = "zone"
+PAGE_TITLE_1 = "pageTitle1"
+PAGE_TITLE_2 = "pageTitle2"
 
 
-ruleTypeLabels = OrderedDict((
+ruleTypeLabels = {
 	# Translators: The label for a rule type.
-	(MARKER, _("Marker")),
+	MARKER: _("Marker"),
 	# Translators: The label for a rule type.
-	(ZONE, _("Zone")),
+	ZONE: _("Zone"),
 	# Translators: The label for a rule type.
-	(PAGE_TITLE_1, _("Page main title")),
+	PAGE_TYPE: _("Page type"),
 	# Translators: The label for a rule type.
-	(PAGE_TITLE_2, _("Page secondary title")),
+	PARENT: _("Parent element"),
 	# Translators: The label for a rule type.
-	(PAGE_TYPE, _("Page type")),
+	PAGE_TITLE_1: _("Page main title"),
 	# Translators: The label for a rule type.
-	(PARENT, _("Parent element")),
-))
+	PAGE_TITLE_2: _("Page secondary title")
+}

--- a/addon/globalPlugins/webAccess/ruleHandler/ruleTypes.py
+++ b/addon/globalPlugins/webAccess/ruleHandler/ruleTypes.py
@@ -42,15 +42,15 @@ ZONE = "zone"
 
 ruleTypeLabels = OrderedDict((
 	# Translators: The label for a rule type.
+	(MARKER, _("Marker")),
+	# Translators: The label for a rule type.
+	(ZONE, _("Zone")),
+	# Translators: The label for a rule type.
 	(PAGE_TITLE_1, _("Page main title")),
 	# Translators: The label for a rule type.
 	(PAGE_TITLE_2, _("Page secondary title")),
 	# Translators: The label for a rule type.
 	(PAGE_TYPE, _("Page type")),
 	# Translators: The label for a rule type.
-	(ZONE, _("Zone")),
-	# Translators: The label for a rule type.
 	(PARENT, _("Parent element")),
-	# Translators: The label for a rule type.
-	(MARKER, _("Marker")),
 ))


### PR DESCRIPTION
- Changed the default ruleType selection to the first item for user convenience.
- Reordered "Marker" and "Zone" to the top for better visibility and logical grouping.
