### PR TITLE
GUI: standardize action button labels by changing "New..." to "Add..."

### DIFF
--- a/addon/globalPlugins/webAccess/gui/actions.py
+++ b/addon/globalPlugins/webAccess/gui/actions.py
@@ -102,7 +102,7 @@ class ActionsPanelBase(RuleAwarePanelBase, metaclass=guiHelper.SIPABCMeta):
 		
 		col += 1
 		# Translators: The label for a button in the Rule Editor dialog
-		item = self.addButton = wx.Button(self, label=_("&New..."))
+		item = self.addButton = wx.Button(self, label=_("&Add..."))
 		item.Bind(wx.EVT_BUTTON, self.onAddGesture)
 		items.append(item)
 		gbSizer.Add(item, pos=(row, col), flag=wx.EXPAND)

--- a/addon/globalPlugins/webAccess/gui/criteriaEditor.py
+++ b/addon/globalPlugins/webAccess/gui/criteriaEditor.py
@@ -887,7 +887,7 @@ class PropertiesPanel(PropertiesPanelBase, CriteriaEditorPanel):
 		self.listLabel.Label = _("Properties specific to this criteria set")
 		listCtrl = self.listCtrl
 		# Translators: A hint stating a list is empty and how to populate it on the Criteria Editor dialog
-		listCtrl.descriptionIfEmpty = _("None. Press alt+n to override a property.")
+		listCtrl.descriptionIfEmpty = _("None. Press Alt+A to override a property.")
 		# Translators: A column header in the Criteria Editor dialog
 		self.listCtrl.InsertColumn(2, _("Rule value"))
 
@@ -897,7 +897,7 @@ class PropertiesPanel(PropertiesPanelBase, CriteriaEditorPanel):
 
 		col += 1
 		# Translators: The label for a button on the Criteria Editor dialog
-		item = self.addPropBtn = wx.Button(self, label=_("&New")) #FIXME, size=(-1, 30))
+		item = self.addPropBtn = wx.Button(self, label=_("&Add")) #FIXME, size=(-1, 30))
 		item.Enable(False)
 		item.Bind(wx.EVT_BUTTON, self.onAddPropBtn)
 		gbSizer.Add(item, pos=(row, col))

--- a/addon/globalPlugins/webAccess/gui/rule/editor.py
+++ b/addon/globalPlugins/webAccess/gui/rule/editor.py
@@ -355,7 +355,7 @@ class AlternativesPanel(RuleEditorTreeContextualPanel):
 		
 		row = 0
 		# Translators: Label for a control in the Rule Editor
-		item = wx.StaticText(self, label=_("&Alternatives"))
+		item = wx.StaticText(self, label=_("A&lternatives"))
 		gbSizer.Add(item, pos=(row, 0))
 		
 		row += 1
@@ -398,8 +398,8 @@ class AlternativesPanel(RuleEditorTreeContextualPanel):
 		
 		col += 1
 		# Translators: The label for a button on the Rule Editor dialog
-		item = self.newButton = wx.Button(self, label=_("&New..."))
-		item.Bind(wx.EVT_BUTTON, self.onNewCriteria)
+		item = self.newButton = wx.Button(self, label=_("&Add..."))
+		item.Bind(wx.EVT_BUTTON, self.onAddCriteria)
 		gbSizer.Add(item, pos=(row, col))
 		
 		row += 1
@@ -457,7 +457,7 @@ class AlternativesPanel(RuleEditorTreeContextualPanel):
 		self.refreshParent(self.categoryParams.treeNode)
 
 	@guarded
-	def onNewCriteria(self, evt):
+	def onAddCriteria(self, evt):
 		context = self.context
 		prm = self.categoryParams
 		context["data"]["criteria"] = OrderedDict({
@@ -643,8 +643,8 @@ class ChildAlternativePanel(AlternativesPanel):
 		# Keep natural visual ordering but set last in tab order
 		row = summaryStartRow
 		# Translators: New criteria button label
-		item = self.newButton = wx.Button(self, label=_("&New..."))
-		item.Bind(wx.EVT_BUTTON, self.onNewCriteria)
+		item = self.newButton = wx.Button(self, label=_("&Add..."))
+		item.Bind(wx.EVT_BUTTON, self.onAddCriteria)
 		gbSizer.Add(item, pos=(row, col))
 		
 		row += 1
@@ -736,7 +736,7 @@ class ChildActionPanel(RuleEditorTreeContextualPanel):
 		# Keep natural visual ordering but set last in tab order
 		col = 0
 		# Translators: The label for a button on the Rule Editor dialog
-		item = wx.Button(self, label=_("&New..."))
+		item = wx.Button(self, label=_("&Add..."))
 		item.Bind(wx.EVT_BUTTON, self.onAddGesture)
 		gbSizer.Add(item, pos=(row, col))
 		


### PR DESCRIPTION
- Changed button labels from "&New..." to "&Add..." to maintain consistency with other action buttons that use verbs (e.g., Edit and Delete), and to prevent translation complications related to gender, such as "nouveau" and "nouvelle" in French.
- Updated the description hint for empty lists in the Criteria Editor from "Press alt+n" to "Press Alt+A."
- Modified the label for alternatives from "&Alternatives" to "A&lternatives" to avoid conflict with the "&Add" shortcut key.
- Renamed the event handler from `onNewCriteria` to `onAddCriteria` for better alignment.
