### PR TITLE
Gesture Scopes

### DIFF
--- a/addon/globalPlugins/webAccess/gui/rule/gestureBinding.py
+++ b/addon/globalPlugins/webAccess/gui/rule/gestureBinding.py
@@ -41,6 +41,7 @@ from gui import guiHelper
 import speech
 import ui
 
+from ...ruleHandler import GestureScope
 from ...utils import guarded, logException
 from .. import ScalingMixin, showContextualDialog
 
@@ -52,6 +53,16 @@ else:
 
 
 addonHandler.initTranslation()
+
+
+SCOPE_LABELS = {
+	# Translators: Gesture Scope
+	GestureScope.GLOBAL.value: pgettext("webAccess.gestureScope", "global"),
+	# Translators: Gesture Scope
+	GestureScope.NORMAL.value: pgettext("webAccess.gestureScope", "normal"),
+	# Translators: Gesture Scope
+	GestureScope.LOCAL.value: pgettext("webAccess.gestureScope", "local"),
+}
 
 
 class GestureBindingDialog(wx.Dialog, ScalingMixin):
@@ -79,6 +90,7 @@ class GestureBindingDialog(wx.Dialog, ScalingMixin):
 		vSizer.Add(gbSizer, flag=wx.ALL | wx.EXPAND, border=guiHelper.BORDER_FOR_DIALOGS, proportion=1)
 		
 		row = 0
+		# Translators: The label for a field on the Gesture Binding dialog
 		item = wx.StaticText(self, label=_("Gesture: "))
 		gbSizer.Add(item, pos=(row, 0), flag=wx.EXPAND)
 		gbSizer.Add((guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
@@ -88,11 +100,22 @@ class GestureBindingDialog(wx.Dialog, ScalingMixin):
 		row += 1
 		gbSizer.Add((0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
 		row += 1
+		# Translators: The label for a field on the Gesture Binding dialog
 		item = wx.StaticText(self, label=_("&Action to execute"))
 		gbSizer.Add(item, pos=(row, 0), flag=wx.EXPAND)
 		gbSizer.Add((guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
 		item = self.actionChoice = wx.Choice(self)
 		item.Bind(wx.EVT_CHOICE, self.onActionChoice)
+		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
+		row += 1
+		gbSizer.Add((0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		row += 1
+		# Translators: The label for a field on the Gesture Binding dialog
+		item = wx.StaticText(self, label=_("&Scope"))
+		gbSizer.Add(item, pos=(row, 0), flag=wx.EXPAND)
+		gbSizer.Add((guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
+		item = self.scopeChoice = wx.Choice(self)
+		item.Bind(wx.EVT_CHOICE, self.onScopeChoice)
 		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
 		
 		gbSizer.AddGrowableCol(2)
@@ -123,17 +146,31 @@ class GestureBindingDialog(wx.Dialog, ScalingMixin):
 		data = self.getData()
 		data["oldId"] = data["newId"] = data.pop("gestureIdentifier", None)
 		self.updateGestureInput()
+		
 		# Translators: A prompt for selection in the action list on the Input Gesture dialog
 		actions = data["actions"] = {None: _("Select an action")}
 		mgr = context["webModule"].ruleManager
 		actions.update(mgr.getActions())
+		action = data.get("action")
+		if action is not None and action not in actions:
+			actions[action] = f"*{action}"
 		self.actionChoice.AppendItems(tuple(actions.values()))
-		self.actionChoice.Selection = tuple(actions.keys()).index(data.get("action", None))
+		self.actionChoice.Selection = tuple(actions.keys()).index(action)
+		
+		scope = data.setdefault("scope", GestureScope.NORMAL.value)
+		self.scopeChoice.AppendItems(tuple(SCOPE_LABELS.values()))
+		self.scopeChoice.Selection = tuple(SCOPE_LABELS.keys()).index(scope)
 	
 	@guarded
 	def onActionChoice(self, evt):
 		data = self.getData()
 		data["action"] = tuple(data["actions"].keys())[evt.Selection]
+		evt.Skip()
+	
+	@guarded
+	def onScopeChoice(self, evt):
+		data = self.getData()
+		data["scope"] = tuple(SCOPE_LABELS.keys())[evt.Selection]
 		evt.Skip()
 	
 	@guarded
@@ -175,11 +212,12 @@ class GestureBindingDialog(wx.Dialog, ScalingMixin):
 		gestures = self.context["data"]["gestures"]
 		oldId = data.pop("oldId")
 		newId = data["gestureIdentifier"] = data.pop("newId")
+		scope = data["scope"]
 		action = data["action"]
 		tmp = gestures.copy()
 		if oldId:
 			del tmp[oldId]
-		tmp[newId] = action
+		tmp[newId] = (scope, action)
 		gestures.clear()
 		gestures.update({k : tmp[k] for k in sorted(tmp)})
 		data["index"] = tuple(gestures.keys()).index(newId)

--- a/addon/globalPlugins/webAccess/gui/rule/gestures.py
+++ b/addon/globalPlugins/webAccess/gui/rule/gestures.py
@@ -38,8 +38,8 @@ import inputCore
 import gui
 from gui import guiHelper
 
-from ...ruleHandler import ruleTypes
-from ...utils import guarded
+from ...ruleHandler import GestureScope, ruleTypes
+from ...utils import guarded, translate
 from .. import ContextualSettingsPanel, Change
 from . import gestureBinding
 from .abc import RuleAwarePanelBase
@@ -54,6 +54,13 @@ else:
 addonHandler.initTranslation()
 
 
+SCOPE_LABELS = {
+	# Translators: The label for a gesture binding scope
+	GestureScope.GLOBAL.value: _("Global scope"),
+	# Translators: The label for a gesture binding scope
+	GestureScope.LOCAL.value: _("Local scope"),
+}
+
 class GesturesPanelBase(RuleAwarePanelBase, metaclass=guiHelper.SIPABCMeta):
 	"""ABC for Gestures panels
 	
@@ -65,8 +72,8 @@ class GesturesPanelBase(RuleAwarePanelBase, metaclass=guiHelper.SIPABCMeta):
 	 - `ruleEditor.GesturesPanel`
 	"""
 
-	# Translators: The label for a category in the Rule and Criteria editors
-	title = _("Input Gestures")
+	# Use translation from NVDA core
+	title = translate("Input Gestures")
 	
 	# Translators: Displayed when the selected rule type doesn't support input gestures
 	descriptionIfNoneSupported = _("The selected Rule Type does not support Input Gestures.")
@@ -178,10 +185,11 @@ class GesturesPanelBase(RuleAwarePanelBase, metaclass=guiHelper.SIPABCMeta):
 		context = self.context
 		id = self.getSelectedGesture()
 		data = context["data"]
+		gestures = data["gestures"] = self.gesturesMap
+		scope, action = gestures[id]
 		data["gestureBinding"] = {
-			"gestureIdentifier": id, "action":  self.gesturesMap[id]
+			"gestureIdentifier": id, "action": action, "scope": scope
 		}
-		data["gestures"] = self.gesturesMap
 		if gestureBinding.show(context=context, parent=self):
 			id = data["gestureBinding"]["gestureIdentifier"]
 			self.onGestureChange(Change.UPDATE, id)
@@ -201,14 +209,14 @@ class GesturesPanelBase(RuleAwarePanelBase, metaclass=guiHelper.SIPABCMeta):
 		listBox = self.gesturesListBox
 		listBox.Clear()
 		selectIndex = 0
-		for index, (gestureIdentifier, action) in enumerate(map.items()):
+		for index, (gestureIdentifier, (scope, action)) in enumerate(map.items()):
 			source, main = inputCore.getDisplayTextForGestureIdentifier(gestureIdentifier)
 			actionDName = mgr.getActions().get(action, f"*{action}")
-			listBox.Append(
 				# Translators: A gesture binding on the editor dialogs
-				"{gesture}: {action}".format(gesture=main, action=actionDName),
-				gestureIdentifier
-			)
+			label = "{gesture}: {action}".format(gesture=main, action=actionDName)
+			if scope != GestureScope.NORMAL.value:
+				label += f" - {SCOPE_LABELS[scope]}"
+			listBox.Append(label, gestureIdentifier)
 			if gestureIdentifier == selectId:
 				selectIndex = index
 		if self.gesturesMap:

--- a/addon/globalPlugins/webAccess/gui/rule/manager.py
+++ b/addon/globalPlugins/webAccess/gui/rule/manager.py
@@ -41,7 +41,7 @@ import inputCore
 import queueHandler
 import ui
 
-from ...ruleHandler import Rule, Result, Zone, ruleTypes
+from ...ruleHandler import GestureScope, Rule, Result, Zone, ruleTypes
 from ...utils import guarded
 from ...webModuleHandler import getEditableWebModule, save
 from .. import ContextualDialog, showContextualDialog, stripAccel
@@ -62,6 +62,16 @@ except ImportError:
 
 
 addonHandler.initTranslation()
+
+
+SCOPE_LABELS = {
+	# Translators: The label for a gesture binding scope
+	GestureScope.GLOBAL: _("Global scope"),
+	# Translators: The label for a gesture binding scope
+	GestureScope.NORMAL: _("Normal scope"),
+	# Translators: The label for a gesture binding scope
+	GestureScope.LOCAL: _("Local scope"),
+}
 
 
 lastGroupBy = "position"
@@ -129,7 +139,7 @@ def rule_getResults_safe(rule):
 
 
 def iterRulesByGesture(ruleManager, filter=None, active=False):
-	gestures = {}
+	scopes = {}
 	noGesture = []
 	
 	for rule in getRules(ruleManager):
@@ -137,8 +147,10 @@ def iterRulesByGesture(ruleManager, filter=None, active=False):
 			continue
 		if active and not rule_getResults_safe(rule):
 			continue
-		for gesture, action in iteritems(rule.gestures):
-			rules = gestures.setdefault(getGestureLabel(gesture), [])
+		for gesture, (scope, action) in rule.gestures.items():
+			rules = scopes.setdefault(
+				scope, {}
+			).setdefault(getGestureLabel(gesture), [])
 			rules.append(TreeItemData(
 				label=(
 					"{rule} - {action}".format(
@@ -155,15 +167,26 @@ def iterRulesByGesture(ruleManager, filter=None, active=False):
 			noGesture.append(
 				TreeItemData(label=rule.name, obj=rule, children=[])
 			)
-	for gesture, tids in sorted(
-		list(gestures.items()),
-		key=lambda kvp: kvp[0]
-	):
-		yield TreeItemData(
-			label=gesture,
-			obj=None,
-			children=sorted(tids, key=lambda tid: tid.label)
-		)
+	normalScopeOnly = len(scopes) == 1 and scopes.get(GestureScope.NORMAL)
+	for scope, gestures in scopes.items():
+		scopeChildren = []
+		for gesture, gestureChildren in sorted(
+			list(gestures.items()),
+			key=lambda kvp: kvp[0]
+		):
+			scopeChildren.append(TreeItemData(
+				label=gesture,
+				obj=None,
+				children=sorted(gestureChildren, key=lambda tid: tid.label)
+			))
+		if normalScopeOnly:
+			yield from scopeChildren
+		else:
+			yield TreeItemData(
+				label=SCOPE_LABELS[scope],
+				obj=None,
+				children=scopeChildren
+			)
 	if noGesture:
 		yield TreeItemData(
 			# Translator: TreeItem label on the RulesManager dialog.

--- a/addon/globalPlugins/webAccess/ruleHandler/__init__.py
+++ b/addon/globalPlugins/webAccess/ruleHandler/__init__.py
@@ -29,6 +29,8 @@ __authors__ = (
 )
 
 
+from collections import ChainMap
+from enum import Enum
 from functools import partial
 from itertools import chain
 from pprint import pformat
@@ -91,6 +93,12 @@ builtinActions = {
 	# Translators: Action name
 	"mouseMove": pgettext("webAccess.action", "Mouse move"),
 }
+
+
+class GestureScope(Enum):
+	GLOBAL = "global"
+	NORMAL = "normal"
+	LOCAL = "local"
 
 
 class DefaultScripts(ScriptableObject):
@@ -346,8 +354,7 @@ class RuleManager(ScriptableObject):
 				if subMod is not caret:
 					yield partial(subMod.ruleManager.getGlobalScript, caret=caret, fromParent=True)
 			for result in self.getResults():
-				if result.rule.type == ruleTypes.GLOBAL_MARKER:
-					yield result.getScript
+				yield partial(result.getSpecialScript, scope=GestureScope.GLOBAL)
 			if not fromParent and self.parentZone:
 				parent = self.parentRuleManager
 				if parent.webModule is not caret:
@@ -357,21 +364,38 @@ class RuleManager(ScriptableObject):
 			script = func(gesture)
 			if script:
 				return script		
-
+	
+	def getLocalScript(self, gesture):
+		caret = self.nodeManager.treeInterceptor.selection
+		
+		scripts = []
+		for result in self.getResults():
+			script = result.getSpecialScript(gesture, GestureScope.LOCAL, caret=caret)
+			if script:
+				scripts.append((result.context, script))
+		
+		if scripts:
+			
+			def sortKey(pair):
+				ctx, script = pair
+				return ctx.endOffset - ctx.startOffset, ctx.startOffset
+			scripts.sort(key=sortKey)
+			return scripts[0][1]
+	
 	def getScript(self, gesture):
 		script = super().getScript(gesture)
 		if script:
 			return script
+		script = self.getLocalScript(gesture)
+		if script:
+			return script
+		for result in self.getResults():
+			script = result.getScript(gesture)
+			if script is not None:
+				return script
 		script = self.getGlobalScript(gesture)
 		if script:
 			return script
-		for layer in reversed(list(self._layers.keys())):
-			for result in self.getResults():
-				if result.rule.type is ruleTypes.GLOBAL_MARKER or result.rule.layer != layer:
-					continue
-				script = result.getScript(gesture)
-				if script:
-					return script
 		# Handle script_notFound fallback 
 		for rules in reversed(list(self._layers.values())):
 			for rule in list(rules.values()):
@@ -1017,6 +1041,7 @@ class Result(ScriptableObject):
 		rule = criteria.rule
 		self._rule = weakref.ref(rule)
 		self.zone = Zone(self) if rule.type == ruleTypes.ZONE else None
+		self._specialGestureMap = {}
 		webModule = rule.ruleManager.webModule
 		prefix = "action_"
 		for key in dir(webModule):
@@ -1031,13 +1056,15 @@ class Result(ScriptableObject):
 				dispatcher.webModules.add(webModule)
 				setattr(self.__class__, scriptAttrName, dispatcher)
 				setattr(self, scriptAttrName, dispatcher.__get__(self))
-		self.bindGestures({
-			gestureId: action
-			for gestureId, action in rule.gestures.items()
-			if gestureId not in criteria.gestures
-		})
-		self.bindGestures(criteria.gestures)
-
+		
+		for gestureId, (scope, action) in ChainMap(
+			criteria.gestures, rule.gestures
+		).items():
+			if scope is GestureScope.NORMAL:
+				self.bindGesture(gestureId, action)
+			else:
+				self.bindSpecialGesture(gestureId, scope, action)
+	
 	def __repr__(self):
 		try:
 			return f"<{type(self).__name__} of {self.rule.name!r} at {self.startOffset, self.endOffset}>"
@@ -1100,7 +1127,37 @@ class Result(ScriptableObject):
 			return self.startOffset < other.startOffset
 		except AttributeError as e:
 			raise TypeError(f"'<' not supported between instances of '{type(self)}' and '{type(other)}'") from e
-
+	
+	def bindSpecialGesture(self, gestureId, scope, action):
+		try:
+			attrName = f"script_{action}"
+			func = getattr(self.__class__, attrName)
+			normalizedId = inputCore.normalizeGestureIdentifier(gestureId)
+			self._specialGestureMap.setdefault(scope, {})[normalizedId] = func
+		except Exception:
+			log.exception("Could not bind to action {action} for {webModule} / {rule}".format(
+				action=action,
+				webModule=self.rule.ruleManager.webModule.name,
+				rule=self.rule.name,
+			))
+	
+	def getSpecialScript(self, gesture, scope, caret: textInfos.offsets.Offsets = None):
+		gestureMap = self._specialGestureMap.get(scope)
+		if not gestureMap:
+			return None
+		if scope is GestureScope.LOCAL:
+			if caret is None:
+				raise ValueError(f"caret is mandatory for {scope}")
+			ctx = self.context
+			if ctx is None or not(ctx.startOffset <= caret._startOffset < ctx.endOffset):
+				return None
+		for identifier in gesture.normalizedIdentifiers:
+			try:
+				# Convert to instance method.
+				return gestureMap[identifier].__get__(self, self.__class__)
+			except KeyError:
+				continue
+	
 	def containsNode(self, node):
 		offset = node.offset
 		return self.startOffset <= offset and self.endOffset >= offset + node.size
@@ -1291,13 +1348,12 @@ class Criteria(ScriptableObject):
 		self.url = data.pop("url", None)
 		self.relativePath = data.pop("relativePath", None)
 		self.index = data.pop("index", None)
-		self.gestures = data.pop("gestures", {})
-		if self.text:
-			self.text = self.text.strip()
+		self.gestures = {
+			gestureId: (GestureScope(scopeName), action)
+			for gestureId, (scopeName, action)
+			in data.pop("gestures", {}).items()
+		}
 		gesturesMap = {}
-		for gestureIdentifier in list(self.gestures.keys()):
-			gesturesMap[gestureIdentifier] = "notFound"
-		# self.bindGestures(gesturesMap)
 		self.properties.load(data.pop("properties", {}))
 		if data:
 			raise ValueError(
@@ -1333,7 +1389,11 @@ class Criteria(ScriptableObject):
 		setIfNotNoneOrEmptyString("url", self.url)
 		setIfNotNoneOrEmptyString("relativePath", self.relativePath)
 		setIfNotDefault("index", self.index)
-		setIfNotDefault("gestures", self.gestures, {})
+		gestures = {
+			grestureId: (scope.value, actionId)
+			for gestureId, (scope, actionId) in self.gestures
+		}
+		setIfNotDefault("gestures", gestures, {})
 		setIfNotDefault("properties", self.properties.dump(), {})
 
 		return data
@@ -1546,7 +1606,11 @@ class Rule(ScriptableObject):
 		data["name"] = self.name
 		data["type"] = self.type
 		setIfNotNoneOrEmptyString("comment", self.comment)
-		setIfNotDefault("gestures", self.gestures, {})
+		gestures = {
+			gestureId: (scope.value, actionId)
+			for gestureId, (scope, actionId) in self.gestures.items()
+		}
+		setIfNotDefault("gestures", gestures, {})
 		if self.criteria:
 			items = data["criteria"] = []
 			for criteria in self.criteria:
@@ -1561,11 +1625,11 @@ class Rule(ScriptableObject):
 		self.type = data.pop("type")
 		self.comment = data.pop("comment", None)
 		self.criteria = [Criteria(self, criteria) for criteria in data.pop("criteria", [])]
-		self.gestures = data.pop("gestures", {})
-		gesturesMap = {}
-		for gestureIdentifier in list(self.gestures.keys()):
-			gesturesMap[gestureIdentifier] = "notFound"
-		self.bindGestures(gesturesMap)
+		self.gestures = {
+			gestureId: (GestureScope(scopeName), action)
+			for gestureId, (scopeName, action)
+			in data.pop("gestures", {}).items()
+		}
 		self.properties.load(data.pop("properties", {}))
 		if data:
 			raise ValueError(
@@ -1574,6 +1638,12 @@ class Rule(ScriptableObject):
 				+ ": "
 				+ ", ".join(list(data.keys()))
 			)
+		self.bindGestures({
+			gestureId: ("notFoundLocally" if scope is GestureScope.LOCAL else "notFound")
+			for gestureId, (scope, action) in ChainMap(
+				self.gestures, *(crit.gestures for crit in self.criteria)
+			).items()
+		})
 
 	def createResult(self, criteria, node, context, index):
 		return SingleNodeResult(criteria, node, context, index)
@@ -1592,6 +1662,11 @@ class Rule(ScriptableObject):
 
 	def script_notFound(self, gesture):
 		speech.speakMessage(_("{ruleName} not found").format(
+			ruleName=self.label)
+		)
+
+	def script_notFoundLocally(self, gesture):
+		speech.speakMessage(_("{ruleName} not found locally").format(
 			ruleName=self.label)
 		)
 

--- a/addon/globalPlugins/webAccess/ruleHandler/properties.py
+++ b/addon/globalPlugins/webAccess/ruleHandler/properties.py
@@ -94,7 +94,7 @@ class PropertySpec(Enum):
 		hasSuggestions=False,
 	)
 	multiple = PropertySpecValue(
-		ruleTypes=(ruleTypes.GLOBAL_MARKER, ruleTypes.MARKER, ruleTypes.PARENT, ruleTypes.ZONE),
+		ruleTypes=(ruleTypes.MARKER, ruleTypes.PARENT, ruleTypes.ZONE),
 		valueType=bool,
 		default=False,
 		# Translators: The display name for a rule property
@@ -104,7 +104,7 @@ class PropertySpec(Enum):
 		hasSuggestions=False,
 	)
 	formMode = PropertySpecValue(
-		ruleTypes=(ruleTypes.GLOBAL_MARKER, ruleTypes.MARKER, ruleTypes.ZONE),
+		ruleTypes=(ruleTypes.MARKER, ruleTypes.ZONE),
 		valueType=bool,
 		default=False,
 		# Translators: The display name for a rule property
@@ -114,7 +114,7 @@ class PropertySpec(Enum):
 		hasSuggestions=False,
 	)
 	skip = PropertySpecValue(
-		ruleTypes=(ruleTypes.GLOBAL_MARKER, ruleTypes.MARKER, ruleTypes.ZONE),
+		ruleTypes=(ruleTypes.MARKER, ruleTypes.ZONE),
 		valueType=bool,
 		default=False,
 		# Translators: The display name for a rule property
@@ -124,7 +124,7 @@ class PropertySpec(Enum):
 		hasSuggestions=False,
 	)
 	sayName = PropertySpecValue(
-		ruleTypes=(ruleTypes.GLOBAL_MARKER, ruleTypes.MARKER, ruleTypes.ZONE),
+		ruleTypes=(ruleTypes.MARKER, ruleTypes.ZONE),
 		valueType=bool,
 		default=False,
 		# Translators: The display name for a rule property
@@ -134,7 +134,7 @@ class PropertySpec(Enum):
 		hasSuggestions=False,
 	)
 	customName = PropertySpecValue(
-		ruleTypes=(ruleTypes.GLOBAL_MARKER, ruleTypes.MARKER, ruleTypes.ZONE),
+		ruleTypes=(ruleTypes.MARKER, ruleTypes.ZONE),
 		valueType=str,
 		default="",
 		# Translators: The display name for a rule property
@@ -146,7 +146,6 @@ class PropertySpec(Enum):
 	)
 	customValue = PropertySpecValue(
 		ruleTypes=(
-			ruleTypes.GLOBAL_MARKER,
 			ruleTypes.MARKER,
 			ruleTypes.PAGE_TITLE_1,
 			ruleTypes.PAGE_TITLE_2,
@@ -155,7 +154,7 @@ class PropertySpec(Enum):
 		valueType=str,
 		default="",
 		displayName={
-			(ruleTypes.GLOBAL_MARKER, ruleTypes.MARKER, ruleTypes.ZONE):
+			(ruleTypes.MARKER, ruleTypes.ZONE):
 				# Translators: The display name for a rule property
 				pgettext("webAccess.ruleProperty", "Custom message"),
 			("pageTitle1", "pageTitle2"):
@@ -168,7 +167,7 @@ class PropertySpec(Enum):
 		hasSuggestions=False,
 	)
 	mutation = PropertySpecValue(
-		ruleTypes=(ruleTypes.GLOBAL_MARKER, ruleTypes.MARKER, ruleTypes.ZONE),
+		ruleTypes=(ruleTypes.MARKER, ruleTypes.ZONE),
 		valueType=str,
 		default=None,
 		# Translators: The display name for a rule property

--- a/addon/globalPlugins/webAccess/ruleHandler/ruleTypes.py
+++ b/addon/globalPlugins/webAccess/ruleHandler/ruleTypes.py
@@ -30,7 +30,6 @@ import addonHandler
 addonHandler.initTranslation()
 
 
-GLOBAL_MARKER = "globalMarker"
 MARKER = "marker"
 ZONE = "zone"
 PAGE_TYPE = "pageType"
@@ -38,11 +37,9 @@ PARENT = "parent"
 PAGE_TITLE_1 = "pageTitle1"
 PAGE_TITLE_2 = "pageTitle2"
 
-ACTION_TYPES = (GLOBAL_MARKER, MARKER, ZONE)
+ACTION_TYPES = (MARKER, ZONE)
 
 ruleTypeLabels = {
-	# Translators: The label for a rule type.
-	GLOBAL_MARKER: _("Global Marker"),
 	# Translators: The label for a rule type.
 	MARKER: _("Marker"),
 	# Translators: The label for a rule type.

--- a/addon/globalPlugins/webAccess/store/webModule.py
+++ b/addon/globalPlugins/webAccess/store/webModule.py
@@ -61,7 +61,7 @@ except ImportError:
 
 class WebModuleJsonFileDataStore(Store):
 
-	def __init__(self, name, basePath, dirName="webModulesMC"):
+	def __init__(self, name, basePath, dirName="webModules_gestureScope"):
 		super().__init__(name=name)
 		self.basePath = basePath
 		self.path = os.path.join(basePath, dirName)

--- a/addon/globalPlugins/webAccess/utils.py
+++ b/addon/globalPlugins/webAccess/utils.py
@@ -108,6 +108,20 @@ def logException(func):
 	return wrapper
 
 
+def translate(text):
+	"""
+	Use translation from NVDA core.
+	
+	When this function is used instead of the usual `_` gettext function,
+	SCons ignores it and does not create a new entry in the generated `.pot`
+	file.
+	"""
+	# `addonHandler.initTranslation` stores `_` as a module attribute.
+	# `builtins` contains the one used by NVDA itself.
+	import builtins
+	return builtins._(text)
+
+
 def tryInt(value):
 	"""Try to convert the given value to `int`
 	

--- a/addon/globalPlugins/webAccess/webModuleHandler/__init__.py
+++ b/addon/globalPlugins/webAccess/webModuleHandler/__init__.py
@@ -47,7 +47,7 @@ from ..store import MalformedRefError
 from ..utils import notifyError
 
 
-PACKAGE_NAME = "webModulesMC"
+PACKAGE_NAME = "webModules_gestureScope"
 
 store = None
 _catalog = None

--- a/addon/globalPlugins/webAccess/webModuleHandler/dataRecovery/__init__.py
+++ b/addon/globalPlugins/webAccess/webModuleHandler/dataRecovery/__init__.py
@@ -82,6 +82,9 @@ def recover(data):
 	if formatVersion < version.parse("0.9-dev"):
 		recoverFrom_0_8_to_0_9(data)
 		formatVersion = version.parse(data["formatVersion"])
+	if formatVersion < version.parse("0.11-dev"):
+		recoverFrom_0_10_to_0_11(data)
+		formatVersion = version.parse(data["formatVersion"])
 	
 	from ..webModule import WebModule
 	if formatVersion > WebModule.FORMAT_VERSION:
@@ -539,3 +542,26 @@ def recoverFrom_0_8_to_0_9(data):
 			process(crit, ruleMap.new_child(crit.get("properties", {})))
 	
 	data["formatVersion"] = "0.9-dev"
+
+
+def recoverFrom_0_10_to_0_11(data):
+	
+	def process(scope, data):
+		gestures = data.get("gestures")
+		if gestures:
+			data["gestures"] = {
+				gestureId: (scope, action)
+				for gestureId, action in gestures.items()
+			}
+		
+	for rule in data.get("Rules", {}).values():
+		if rule["type"] == "globalMarker":
+			scope = "global"
+			rule["type"] = "marker"
+		else:
+			scope = "normal"
+		process(scope, rule)
+		for crit in rule.get("criteria", []):
+			process(scope, crit)
+	
+	data["formatVersion"] = "0.11-dev"

--- a/addon/globalPlugins/webAccess/webModuleHandler/webModule.py
+++ b/addon/globalPlugins/webAccess/webModuleHandler/webModule.py
@@ -101,7 +101,7 @@ class WebModule(baseObject.ScriptableObject):
 
 	API_VERSION = version.parse("0.6")
 
-	FORMAT_VERSION_STR = "0.10-dev"
+	FORMAT_VERSION_STR = "0.11-dev"
 	FORMAT_VERSION = version.parse(FORMAT_VERSION_STR)
 
 	def __init__(self):

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -21,8 +21,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2024-12-10 15:36+0100\n"
-"PO-Revision-Date: 2024-12-10 16:00+0100\n"
+"POT-Creation-Date: 2025-02-10 09:54+0100\n"
+"PO-Revision-Date: 2025-02-10 09:58+0100\n"
 "Last-Translator: Julien Cochuyt <JulienCochuyt@users.noreply.github.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -45,13 +45,13 @@ msgstr "Bordure de zone"
 #: addon\globalPlugins\webAccess\overlay.py:538
 #: addon\globalPlugins\webAccess\overlay.py:859
 #: addon\globalPlugins\webAccess\overlay.py:880
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:817
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:841
 msgid "Press escape to cancel zone restriction."
 msgstr "Appuyez sur échappement pour ne plus être restreint à la zone."
 
 #. Translators: Complement to quickNav error message in zone.
 #: addon\globalPlugins\webAccess\overlay.py:856
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:814
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:838
 msgid "in this zone."
 msgstr "dans cette zone."
 
@@ -269,7 +269,7 @@ msgstr "Description de l'élément"
 #. Translators: Web Access menu item label.
 #. Translator: The label for a button on the RulesManager dialog.
 #: addon\globalPlugins\webAccess\gui\menu.py:64
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:456
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:479
 msgid "&New rule..."
 msgstr "&Nouvelle règle..."
 
@@ -343,43 +343,43 @@ msgstr ""
 "recommandé)"
 
 #. Translators: Announced when a list is empty
-#: addon\globalPlugins\webAccess\gui\__init__.py:174
+#: addon\globalPlugins\webAccess\gui\__init__.py:176
 msgid "Empty"
 msgstr "Vide"
 
 #. Translator: The placeholder for an invalid value in summary reports
-#: addon\globalPlugins\webAccess\gui\__init__.py:217
+#: addon\globalPlugins\webAccess\gui\__init__.py:219
 msgid "<Invalid>"
 msgstr "<Invalide>"
 
 #. Translators: The label for the list of categories in a multi category settings dialog.
-#: addon\globalPlugins\webAccess\gui\__init__.py:540
+#: addon\globalPlugins\webAccess\gui\__init__.py:546
 msgid "&Categories:"
 msgstr "&Catégories :"
 
 #. Translators: The display value of a yes/no field
 #. Translators: The displayed value of a yes/no rule property
-#: addon\globalPlugins\webAccess\gui\__init__.py:948
+#: addon\globalPlugins\webAccess\gui\__init__.py:954
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:186
 msgid "Yes"
 msgstr "Oui"
 
 #. Translators: The displayed value of a yes/no field
 #. Translators: The displayed value of a yes/no rule property
-#: addon\globalPlugins\webAccess\gui\__init__.py:951
+#: addon\globalPlugins\webAccess\gui\__init__.py:957
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:189
 msgid "No"
 msgstr "Non"
 
 #. Translators: A field label. French typically adds a space before the colon.
-#: addon\globalPlugins\webAccess\gui\__init__.py:1076
+#: addon\globalPlugins\webAccess\gui\__init__.py:1084
 #, python-brace-format
 msgid "{field}:"
 msgstr "{field} :"
 
 #. Translators: The label for a node in the category tree on a multi-category dialog
 #. Translators: A mention on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\__init__.py:1113
+#: addon\globalPlugins\webAccess\gui\__init__.py:1121
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:121
 #, python-brace-format
 msgid "{field}: {value}"
@@ -430,7 +430,7 @@ msgstr "Critères d'évaluation"
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for the General settings panel.
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:277
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:172
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:174
 msgid "General"
 msgstr "Général"
 
@@ -447,8 +447,8 @@ msgstr "Ordre de &séquence :"
 #. Translator: The label for a field on the Criteria editor
 #. Translators: The label for a field on the Rule editor
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:317
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:210
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:386
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:212
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:404
 msgid "Summar&y:"
 msgstr "&Résumé :"
 
@@ -456,15 +456,15 @@ msgstr "&Résumé :"
 #. Translator: The label for a field on the Rule editor
 #. Translators: The label for a field on the Rule editor
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:329
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:222
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:398
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:224
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:416
 msgid "Technical n&otes:"
 msgstr "N&otes techniques :"
 
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for a category in the rule editor
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:387
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:354
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:372
 msgid "Criteria"
 msgstr "Critères"
 
@@ -590,9 +590,9 @@ msgstr "Erreur de syntaxe dans le champ \"{field}\""
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:825
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:839
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:856
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:303
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:315
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:344
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:321
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:333
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:362
 #: addon\globalPlugins\webAccess\gui\webModule\editor.py:275
 #: addon\globalPlugins\webAccess\gui\webModule\editor.py:289
 #: addon\globalPlugins\webAccess\webModuleHandler\__init__.py:357
@@ -644,11 +644,11 @@ msgstr "&Nouveau"
 #. Translators: The label for a button in the
 #. Web Modules Manager dialog
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:911
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:429
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:637
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:730
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:138
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:471
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:447
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:655
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:748
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:145
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:494
 #: addon\globalPlugins\webAccess\gui\webModule\manager.py:126
 msgid "&Delete"
 msgstr "&Supprimer"
@@ -705,27 +705,27 @@ msgstr "Alternative #{index} :"
 
 #. todo: change tooltip's text
 #. Translators: Tooltip for rule type choice list.
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:191
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:193
 msgid "TOOLTIP EXEMPLE"
 msgstr "EXEMPLE DE BULLE D'AIDE"
 
 #. Translators: Error message when no type is chosen before saving the rule
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:302
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:320
 msgid "You must choose a type for this rule"
 msgstr "Vous devez choisir un type pour cette règle"
 
 #. Translators: Error message when no name is entered before saving the rule
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:314
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:332
 msgid "You must choose a name for this rule"
 msgstr "Vous devez choisir un nom pour cette règle"
 
 #. Translators: Error message when another rule with the same name already exists
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:343
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:361
 msgid "There already is another rule with the same name."
 msgstr "Il existe déjà une autre règle portant le même nom."
 
 #. Translators: Label for a control in the Rule Editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:368
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:386
 msgid "&Alternatives"
 msgstr "&Alternatives"
 
@@ -733,10 +733,10 @@ msgstr "&Alternatives"
 #. Translators: New criteria button label
 #. Translators: The label for a button on the Rule Editor dialog
 #. Translators: The label for a button in the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:411
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:644
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:737
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:116
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:429
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:662
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:755
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:123
 msgid "&New..."
 msgstr "&Nouveau..."
 
@@ -745,215 +745,250 @@ msgstr "&Nouveau..."
 #. Translators: The label for a button in the Rule Editor dialog
 #. Translator: The label for a button on the RulesManager dialog.
 #. Translators: The label for a button in the Web Modules Manager dialog
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:420
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:628
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:127
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:463
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:438
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:646
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:134
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:486
 #: addon\globalPlugins\webAccess\gui\webModule\manager.py:103
 msgid "&Edit..."
 msgstr "&Modifier..."
 
 #. Translator: A confirmation prompt on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:503
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:521
 msgid "Are you sure you want to delete this alternative?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette alternative ?"
 
 #. Translator: The title for a confirmation prompt on the Rule editor
 #. Translator: The title for a confirmation prompt on the
 #. RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:505
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:720
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:523
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:743
 msgid "Confirm Deletion"
 msgstr "Confirmation d'effacement"
 
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:593
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:611
 msgid "Summar&y"
 msgstr "&Résumé"
 
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:610
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:628
 msgid "Technical n&otes"
 msgstr "&Notes techniques"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:921
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:931
 msgid "Sub Module {} - New Rule"
 msgstr "Sous-module {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:924
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:934
 msgid "Root Module {} - New Rule"
 msgstr "Module racine {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:927
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:937
 msgid "Web Module {} - New Rule"
 msgstr "Module web {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:932
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:942
 msgid "Sub Module {} - Edit Rule {}"
 msgstr "Sous-module {} - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:935
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:945
 msgid "Root Module {} - Edit Rule {}"
 msgstr "Module racine - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:938
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:948
 msgid "Web Module {} - Edit Rule {}"
 msgstr "Module web {} - Modifier la règle {}"
 
+#. Translators: Gesture Scope
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:60
+msgctxt "webAccess.gestureScope"
+msgid "global"
+msgstr "globale"
+
+#. Translators: Gesture Scope
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:62
+msgctxt "webAccess.gestureScope"
+msgid "normal"
+msgstr "normale"
+
+#. Translators: Gesture Scope
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:64
+msgctxt "webAccess.gestureScope"
+msgid "local"
+msgstr "locale"
+
 #. Translators: The title for a dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:67
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:78
 msgid "Input Gesture"
 msgstr "Gestes de saisie"
 
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:82
+#. Translators: The label for a field on the Gesture Binding dialog
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:94
 msgid "Gesture: "
 msgstr "Geste : "
 
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:91
+#. Translators: The label for a field on the Gesture Binding dialog
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:104
 msgid "&Action to execute"
 msgstr "&Action à exécuter"
 
+#. Translators: The label for a field on the Gesture Binding dialog
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:114
+msgid "&Scope"
+msgstr "&Portée"
+
 #. Translators: A prompt for selection in the action list on the Input Gesture dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:127
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:151
 msgid "Select an action"
 msgstr "Sélectionner une action"
 
 #. Translators: The prompt to enter a gesture on the Input Gesture dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:142
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:179
 msgid "Type now the desired key combination"
 msgstr "Pressez maintenant la combinaison de touches souhaitée"
 
 #. Translators: A message on the Input Gesture dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:158
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:195
 msgid "You must define a shortcut"
 msgstr "Vous devez entrer un geste de commande"
 
 #. Translators: A message on the Input Gesture dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:168
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:205
 msgid "You must choose an action"
 msgstr "Vous devez choisir une action"
 
 #. Translators: Displayed when no gesture as been entered on the Input Gesture dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:201
+#: addon\globalPlugins\webAccess\gui\rule\gestureBinding.py:239
 msgid "None"
 msgstr "Aucune"
 
-#. Translators: The label for a category in the Rule and Criteria editors
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:69
-msgid "Input Gestures"
-msgstr "Gestes de commande"
+#. Translators: The label for a gesture binding scope
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:59
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:69
+msgid "Global scope"
+msgstr "Portée globale"
+
+#. Translators: The label for a gesture binding scope
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:61
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:73
+msgid "Local scope"
+msgstr "Portée locale"
 
 #. Translators: Displayed when the selected rule type doesn't support input gestures
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:72
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:79
 msgid "The selected Rule Type does not support Input Gestures."
 msgstr ""
 "Le type de règle sélectionné ne prend pas en charge les gestes de commande."
 
 #. Translators: The label for a list on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:95
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:102
 msgid "&Gestures"
 msgstr "&Gestes"
 
+#. Translators: The label for a gesture binding scope
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:71
+msgid "Normal scope"
+msgstr "Portée normale"
+
 #. Translator: TreeItem label on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:170
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:193
 msgctxt "webAccess.ruleGesture"
 msgid "<None>"
 msgstr "<Aucun>"
 
 #. Translators: A part of a context grouping label on the Rules Manager
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:205
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:228
 #, python-brace-format
 msgid "Page Title: {contextPageTitle}"
 msgstr "Titre de la page : {contextPageTitle}"
 
 #. Translators: A part of a context grouping label on the Rules Manager
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:208
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:231
 #, python-brace-format
 msgid "Page Type: {contextPageTitle}"
 msgstr "Type de page : {contextPageTitle}"
 
 #. Translators: A part of a context grouping label on the Rules Manager
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:211
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:234
 #, python-brace-format
 msgid "Parent: {contextPageTitle}"
 msgstr "Parent : {contextPageTitle}"
 
 #. Translator: Grouping option on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:317
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:340
 msgctxt "webAccess.rulesGroupBy"
 msgid "&Position"
 msgstr "&Position"
 
 #. Translator: Grouping option on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:323
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:346
 msgctxt "webAccess.rulesGroupBy"
 msgid "&Type"
 msgstr "&Type"
 
 #. Translator: Grouping option on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:329
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:352
 msgctxt "webAccess.rulesGroupBy"
 msgid "&Context"
 msgstr "&Contexte :"
 
 #. Translator: Grouping option on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:335
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:358
 msgctxt "webAccess.rulesGroupBy"
 msgid "&Gestures"
 msgstr "&Geste de commande"
 
 #. Translator: Grouping option on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:341
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:364
 msgctxt "webAccess.rulesGroupBy"
 msgid "Nam&e"
 msgstr "N&om"
 
 #. Translator: A label on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:363
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:386
 msgid "Group by: "
 msgstr "Regrouper par : "
 
 #. Translator: A label on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:376
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:399
 msgid "&Filter: "
 msgstr "&Filtre : "
 
 #. Translator: A label on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:394
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:417
 msgid "Include only rules &active on the current page"
 msgstr "N'inclure que les règles &actives sur la page courante"
 
 #. contentsSizer.Add(descSizer, flag=wx.EXPAND)
 #. Translator: The label for a field on the Rules manager
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:420
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:443
 msgid "Summary"
 msgstr "Résumé"
 
 #. Translator: The label for a field on the Rules manager
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:431
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:454
 msgid "Technical notes"
 msgstr "Notes techniques"
 
 #. Translator: The label for a button on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:447
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:470
 msgid "Move to"
 msgstr "Aller à"
 
 #. Translators: Reported when cycling through rules grouping on the Rules Manager dialog
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:529
-#, fuzzy
-#| msgid "Group by: "
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:552
 msgid "Group by: {}"
-msgstr "Regrouper par : "
+msgstr "Regrouper par : {}"
 
 #. Translator: A confirmation prompt on the RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\manager.py:714
+#: addon\globalPlugins\webAccess\gui\rule\manager.py:737
 msgid "Are you sure you want to delete this rule?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette règle ?"
 
@@ -1230,43 +1265,43 @@ msgstr "Nom personnalisé"
 
 #. Translators: Displayed if no value is set for a given rule property
 #: addon\globalPlugins\webAccess\ruleHandler\properties.py:143
-#: addon\globalPlugins\webAccess\ruleHandler\properties.py:166
+#: addon\globalPlugins\webAccess\ruleHandler\properties.py:165
 msgctxt "webAccess.ruleProperty"
 msgid "<undefined>"
 msgstr "<indéfini>"
 
 #. Translators: The display name for a rule property
-#: addon\globalPlugins\webAccess\ruleHandler\properties.py:160
+#: addon\globalPlugins\webAccess\ruleHandler\properties.py:159
 msgctxt "webAccess.ruleProperty"
 msgid "Custom message"
 msgstr "Message personnalisé"
 
 #. Translators: The display name for a rule property
-#: addon\globalPlugins\webAccess\ruleHandler\properties.py:163
+#: addon\globalPlugins\webAccess\ruleHandler\properties.py:162
 msgctxt "webAccess.ruleProperty"
 msgid "Custom page title"
 msgstr "Titre de page personnalisé"
 
 #. Translators: The display name for a rule property
-#: addon\globalPlugins\webAccess\ruleHandler\properties.py:175
+#: addon\globalPlugins\webAccess\ruleHandler\properties.py:174
 msgctxt "webAccess.ruleProperty"
 msgid "Transform"
 msgstr "Transformation"
 
 #. Translators: Displayed if no value is set for the "Transform" rule property
-#: addon\globalPlugins\webAccess\ruleHandler\properties.py:177
+#: addon\globalPlugins\webAccess\ruleHandler\properties.py:176
 msgctxt "webAccess.ruleProperty.mutation"
 msgid "None"
 msgstr "Aucune"
 
 #. Translators: The display name for a rule property
-#: addon\globalPlugins\webAccess\ruleHandler\properties.py:186
+#: addon\globalPlugins\webAccess\ruleHandler\properties.py:185
 msgctxt "webAccess.ruleProperty"
 msgid "Load sub-module"
 msgstr "Charger le sous-module"
 
 #. Translators: The displayed text if there is no value for the "Load sub-module" property
-#: addon\globalPlugins\webAccess\ruleHandler\properties.py:188
+#: addon\globalPlugins\webAccess\ruleHandler\properties.py:187
 #, fuzzy
 #| msgid "No"
 msgctxt "webAccess.ruleProperty.subModule"
@@ -1274,121 +1309,121 @@ msgid "No"
 msgstr "Non"
 
 #. Translators: The label for a rule type.
-#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:45
-msgid "Global Marker"
-msgstr "Marqueur global"
-
-#. Translators: The label for a rule type.
-#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:47
+#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:44
 msgid "Marker"
 msgstr "Marqueur"
 
 #. Translators: The label for a rule type.
-#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:49
+#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:46
 msgid "Zone"
 msgstr "Zone"
 
 #. Translators: The label for a rule type.
-#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:51
+#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:48
 msgid "Page type"
 msgstr "Type de page"
 
 #. Translators: The label for a rule type.
-#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:53
+#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:50
 msgid "Parent element"
 msgstr "Élément parent"
 
 #. Translators: The label for a rule type.
-#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:55
+#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:52
 msgid "Page main title"
 msgstr "Titre de page - principal"
 
 #. Translators: The label for a rule type.
-#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:57
+#: addon\globalPlugins\webAccess\ruleHandler\ruleTypes.py:54
 msgid "Page secondary title"
 msgstr "Titre de page - secondaire"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:84
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:86
 msgctxt "webAccess.action"
 msgid "Move to"
 msgstr "Aller à"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:86
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:88
 msgctxt "webAccess.action"
 msgid "Say all"
 msgstr "Dire tout"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:88
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:90
 msgctxt "webAccess.action"
 msgid "Speak"
 msgstr "Énoncer"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:90
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:92
 msgctxt "webAccess.action"
 msgid "Activate"
 msgstr "Activer"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:92
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:94
 msgctxt "webAccess.action"
 msgid "Mouse move"
 msgstr "Déplacer la souris"
 
 #. Translators: Reported when attempting an action while WebAccess is not ready
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:755
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:765
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:779
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:789
 msgid "Not ready"
 msgstr "Pas encore prêt"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:794
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:818
 msgid "No previous zone"
 msgstr "Pas de zone précédente"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:797
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:821
 msgid "No next zone"
 msgstr "Pas de zone suivante"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:800
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:824
 msgid "No zone"
 msgstr "Pas de zone"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:804
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:828
 msgid "No marker"
 msgstr "Pas de marqueur"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:807
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:831
 msgid "No previous marker"
 msgstr "Pas de marqueur précédent"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:810
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:834
 msgid "No next marker"
 msgstr "Pas de marqueur suivant"
 
 #. Translators: Speak rule name on "Move to" action
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1149
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1206
 #, python-brace-format
 msgid "Move to {ruleName}"
 msgstr "Aller à {ruleName}"
 
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1514
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1574
 #, python-brace-format
 msgid "{criteriaName} not found"
 msgstr "{criteriaName} non trouvé"
 
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1594
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1664
 #, python-brace-format
 msgid "{ruleName} not found"
 msgstr "{ruleName} introuvable"
+
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1669
+#, python-brace-format
+msgid "{ruleName} not found locally"
+msgstr "{ruleName} introuvable localement"
 
 #. Translators: Presented when requesting a missing contextual help
 #: addon\globalPlugins\webAccess\webModuleHandler\webModule.py:339
@@ -1458,8 +1493,8 @@ msgstr "ou"
 msgid "You may, in NVDA Preferences:"
 msgstr "Vous pouvez, dans les paramètres de NVDA :"
 
-#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:423
-#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:434
+#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:426
+#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:437
 msgid "Recovered from format version {}"
 msgstr "Récupéré depuis le format de version {}"
 
@@ -1477,6 +1512,9 @@ msgid "Web application modules support for modern or complex web sites."
 msgstr ""
 "Gestion des modules d'applications web pour la navigation sur sites web "
 "riches ou complexes."
+
+#~ msgid "Input Gestures"
+#~ msgstr "Gestes de commande"
 
 #~ msgid "Toggle debug mode."
 #~ msgstr "Basculer le mode de débogage."

--- a/buildVars.py
+++ b/buildVars.py
@@ -26,7 +26,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Web application modules support for modern or complex web sites."""),
 	# version
-	"addon_version" : "2025.02.05-dev",
+	"addon_version" : "2025.02.05-dev+gestureScope",
 	# Author(s)
 	"addon_author" : (
 		"Accessolutions (https://accessolutions.fr), "


### PR DESCRIPTION
Fixes #46.

Introduces the new concept of "scope" at gesture level:
 - Global replaces the "global marker" rule type introduced by PR #37.
 - Normal is the usual scope of gesture bindings for markers and zones.
 - Local only applies when triggered from within the area delimited by the context parent.

Bumps JSON format version to 0.11-dev.