### PR TITLE
Free Zones

### DIFF
--- a/addon/globalPlugins/webAccess/gui/rule/criteriaEditor.py
+++ b/addon/globalPlugins/webAccess/gui/rule/criteriaEditor.py
@@ -179,14 +179,56 @@ def getSummary_context(data) -> Sequence[str]:
 	return parts
 
 
-def getSummary(context, data, indent="", condensed=False) -> str:
-	parts = []
-	subParts = getSummary_context(data)
-	if condensed:
-		parts.append(", ".join(subParts))
+def getSummary_selector_full(data, condensed=False) -> Sequence[str]:
+	if len(data) == 2 and "start" in data and "end" in data:
+		parts = []
+		sections = {
+			"start": _("Start:"),
+			"end": _("End:"),
+		}
+		contexts = {
+			key: getSummary_context(data[key])
+			for key in ("start", "end")
+		}
+		sameContext = contexts["start"] == contexts["end"]
+		if sameContext:
+			subParts = next(iter(contexts.values()))
+			if condensed:
+				parts.append(", ".join(subParts))
+			else:
+				parts.extend(subParts)
+		indent = "    "
+		for key in ("start", "end"):
+			if not (condensed and sameContext):
+				parts.append(sections[key])
+			if not sameContext:
+				subParts = contexts[key]
+				if condensed:
+					parts.append(indent + ", ".join(subParts))
+				else:
+					parts.extend((indent + subPart for subPart in subParts))
+			subParts = getSummary_selector_unit(data[key])
+			if condensed:
+				if sameContext:
+					parts.append(f'{sections[key]} {" ".join(subParts)}')
+				else:
+					parts.append(indent + ", ".join(subParts))
+			else:
+				parts.extend((indent + subPart for subPart in subParts))
+		return parts
 	else:
-		parts.extend(subParts)
-	subParts = []
+		parts = []
+		parts.extend(getSummary_context(data))
+		subParts = getSummary_selector_unit(data)
+		if condensed:
+			parts.append(", ".join(subParts))
+		else:
+			parts.extend(subParts)
+		return parts
+
+
+def getSummary_selector_unit(data) -> Sequence[str]:
+	parts = []
 	for key, label in list(CriteriaPanel.FIELDS.items()):
 		if key in CriteriaPanel.CONTEXT_FIELDS or key not in data:
 			continue
@@ -196,15 +238,22 @@ def getSummary(context, data, indent="", condensed=False) -> str:
 				value = translateRoleIdToLbl(value)
 			elif key == "states":
 				value = translateStatesIdToLbl(value)
-		subParts.append("{} {}".format(
+		parts.append("{} {}".format(
 			stripAccel(label),
 			value
 		))
-	if subParts:
-		if condensed:
-			parts.append(", ".join(subParts))
-		else:
-			parts.extend(subParts)
+	if parts:
+		return parts
+	# Translators: A mention on the Criteria Summary report
+	return [_("No criteria")]
+
+
+def getSummary(context, data, indent="", condensed=False) -> str:
+	parts = []
+	
+	parts.extend(getSummary_selector_full(
+		data.get("selector", {}), condensed=condensed
+	))
 	
 	# Properties
 	subParts = []
@@ -228,15 +277,32 @@ def getSummary(context, data, indent="", condensed=False) -> str:
 
 	if parts:
 		return "{}{}".format(indent, "\n{}".format(indent).join(parts))
-	# Translators: A mention on the Criteria Summary report
-	return "{}{}".format(indent, _("No criteria"))
 
 
 @guarded
-def testCriteria(context):
+def testCriteria(context, restrictDualNodeTo=None):
 	ruleData = deepcopy(context["data"]["rule"])
 	ruleData["name"] = "__tmp__"
-	critData = context["data"]["criteria"].copy()
+	if restrictDualNodeTo:
+		critData = {
+			"selector": context["data"]["criteria"]["selector"][
+				restrictDualNodeTo
+			],
+		}
+		caption = {
+			# Translators: The title of a dialog in the Criteria Set editor
+			"start": _("Start Criteria test"),
+			# Translators: The title of a dialog in the Criteria Set editor
+			"end": _("End Criteria test"),
+		}[restrictDualNodeTo]
+	else:
+		critData = context["data"]["criteria"].copy()
+		if isDualNode(context):
+			# Translators: The title of a dialog in the Criteria Set editor
+			caption = _("Combined Criteria test")
+		else:
+			# Translators: The title of a dialog in the Criteria Set editor
+			caption = _("Criteria test")
 	critData.pop("new", None)
 	critData.pop("criteriaIndex", None)
 	ruleData["criteria"] = [critData]
@@ -261,7 +327,30 @@ def testCriteria(context):
 		message = _("Found {} results in {:.3f} seconds.".format(len(results), duration))
 	else:
 		message = _("No result found on the current page.")
-	gui.messageBox(message, caption=_("Criteria test"))
+	gui.messageBox(message, caption=caption)
+
+
+def isDualNode(context):
+	data = context.get("data", {}).get("criteria", {}).get("selector", {})
+	return set(data.keys()) == {"start", "end"}
+
+
+def convertToDualNode(context):
+	if isDualNode(context):
+		raise ValueError("This selector is already dual node")
+	data = context.get("data", {}).get("criteria", {}).get("selector", {})
+	selector = {"start": data.copy(), "end": data.copy()}
+	context["data"].setdefault("criteria", {})["selector"] = selector
+
+
+def convertToSingleNode(context):
+	if not isDualNode(context):
+		raise ValueError("This selector is not dual node")
+	data = context.get("data", {}).get("criteria", {}).get("selector", {})
+	selector = data.pop("start")
+	del data["end"]
+	context["data"].setdefault("criteria", {})["selector"] = selector
+
 
 
 class CriteriaEditorPanel(RuleAwarePanelBase):
@@ -277,7 +366,7 @@ class GeneralPanel(CriteriaEditorPanel):
 	title = _("General")
 	
 	def __init__(self, parent):
-		self.hideable: Sequence[wx.Window] = []
+		self.hideable: Mapping[Sequence[wx.Window]] = {}
 		super().__init__(parent)
 	
 	def makeSettings(self, settingsSizer):
@@ -294,10 +383,11 @@ class GeneralPanel(CriteriaEditorPanel):
 		item = self.criteriaName = wx.TextCtrl(self)
 		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
 
+		items = self.hideable["order"] = []
 		row += 1
 		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		items.append(item)
 
-		items = self.hideable
 		row += 1
 		# Translator: The label for a field on the Criteria editor
 		item = wx.StaticText(self, label=_("&Sequence order:"))
@@ -333,6 +423,36 @@ class GeneralPanel(CriteriaEditorPanel):
 		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
 		gbSizer.AddGrowableRow(row)
 
+		items = self.hideable["convert.dual"] = []
+		row += 1
+		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		items.append(item)
+
+		row += 1
+		# Translators: The label for a button in the Criteria Editor dialog
+		item = wx.Button(self, label=_("Convert to free zone (two sets of criteria)"))
+		item.Bind(wx.EVT_BUTTON, self.Parent.Parent.onConvertToDual)
+		items.append(item)
+		item = gbSizer.Add(item, pos=(row, 0), span=(1, 3), flag=wx.EXPAND)
+		items.append(item)
+		for item in items:
+			item.Show(False)
+
+		items = self.hideable["convert.single"] = []
+		row += 1
+		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		items.append(item)
+
+		row += 1
+		# Translators: The label for a button in the Criteria Editor dialog
+		item = wx.Button(self, label=_("Convert to simple zone (one set of criteria)"))
+		item.Bind(wx.EVT_BUTTON, self.Parent.Parent.onConvertToSingle)
+		items.append(item)
+		item = gbSizer.Add(item, pos=(row, 0), span=(1, 3), flag=wx.EXPAND)
+		items.append(item)
+		for item in items:
+			item.Show(False)
+
 		gbSizer.AddGrowableCol(2)
 	
 	def initData(self, context):
@@ -343,13 +463,17 @@ class GeneralPanel(CriteriaEditorPanel):
 			nbAlternatives += 1
 		data = self.getData()
 		if nbAlternatives == 1:
-			for item in self.hideable:
+			for item in self.hideable["order"]:
 				item.Show(False)
 		else:
 			for index in range(nbAlternatives):
 				self.sequenceOrderChoice.Append(str(index + 1))
 			index = data.get("criteriaIndex", nbAlternatives + 1)
 			self.sequenceOrderChoice.SetSelection(index)
+		if self.getRuleType() == ruleTypes.ZONE:
+			key = "convert.single" if isDualNode(context) else "convert.dual"
+			for item in self.hideable[key]:
+				item.Show(True)
 		self.criteriaName.Value = data.get("name", "")
 		self.commentText.Value = data.get("comment", "")
 		self.refreshSummary()
@@ -609,11 +733,14 @@ class CriteriaPanel(CriteriaEditorPanel):
 		row += 1
 		# Translators: The label for a button in the Criteria Editor dialog
 		item = wx.Button(self, label=_("Test these criteria (F5)"))
-		item.Bind(wx.EVT_BUTTON, self.Parent.Parent.onTestCriteria)
+		item.Bind(wx.EVT_BUTTON, self.onTestCriteria)
 		gbSizer.Add(item, pos=(row, 0), span=(1, 3))
 
 		gbSizer.AddGrowableCol(2)
-	
+
+	def getData(self):
+		return super().getData().setdefault("selector", {})
+
 	def initData(self, context):
 		super().initData(context)
 		data = self.getData()
@@ -742,7 +869,7 @@ class CriteriaPanel(CriteriaEditorPanel):
 				default="advanced"
 			)
 			if initial:
-				data = context["data"]["criteria"]
+				data = self.getData()
 				filled = [
 					field
 					for field in ("contextPageTitle", "contextPageType", "contextParent")
@@ -779,12 +906,13 @@ class CriteriaPanel(CriteriaEditorPanel):
 		self.refreshContextMacroChoices()
 		# self.onContextMacroChoice(None)
 		super().onPanelActivated()
-
-	def spaceIsPressedOnTreeNode(self):
-		self.contextMacroDropDown.SetFocus()
-
+	
+	def onTestCriteria(self, evt):
+		self.updateData()
+		testCriteria(self.context)
+	
 	def isValid(self):
-		data = self.context["data"]["criteria"]
+		data = self.getData()
 		roleLblExpr = self.roleCombo.Value
 		if roleLblExpr.strip():
 			if not EXPR.match(roleLblExpr):
@@ -861,6 +989,30 @@ class CriteriaPanel(CriteriaEditorPanel):
 				return False
 
 		return True
+
+
+class StartCriteriaPanel(CriteriaPanel):
+	# Translators: The label for a Criteria editor category.
+	title = _("Start Criteria")
+	
+	def getData(self):
+		return super().getData()["start"]
+	
+	def onTestCriteria(self, evt):
+		self.updateData()
+		testCriteria(self.context, restrictDualNodeTo=="start")
+
+
+class EndCriteriaPanel(CriteriaPanel):
+	# Translators: The label for a Criteria editor category.
+	title = _("End Criteria")
+	
+	def getData(self):
+		return super().getData()["end"]
+	
+	def onTestCriteria(self, evt):
+		self.updateData()
+		testCriteria(self.context, restrictDualNodeTo="end")
 
 
 class GesturesPanel(GesturesPanelBase, CriteriaEditorPanel):
@@ -993,6 +1145,17 @@ class CriteriaEditorDialog(ContextualMultiCategorySettingsDialog):
 	categoryClasses = [GeneralPanel, CriteriaPanel, GesturesPanel, PropertiesPanel]
 	INITIAL_SIZE = (900, 580)
 	
+	def __init__(self, parent, *args, dualNode=False, **kwargs):
+		if dualNode:
+			self.categoryClasses = [
+				GeneralPanel,
+				StartCriteriaPanel,
+				EndCriteriaPanel,
+				GesturesPanel,
+				PropertiesPanel
+			]
+		super().__init__(parent, *args, **kwargs)
+	
 	def getData(self):
 		# Should always be initialized, as the Rule Editor populates it with at least
 		# the index of this Alternative Criteria Set ("criteriaIndex").
@@ -1000,22 +1163,86 @@ class CriteriaEditorDialog(ContextualMultiCategorySettingsDialog):
 	
 	def makeSettings(self, settingsSizer):
 		super().makeSettings(settingsSizer)
-		idTestCriteria = wx.NewId()
-		self.Bind(wx.EVT_MENU, self.onTestCriteria, id=idTestCriteria)
-		self.SetAcceleratorTable(wx.AcceleratorTable([
-			(wx.ACCEL_NORMAL, wx.WXK_F5, idTestCriteria)
-		]))
+	
+	def onCharHook(self, evt):
+		# Bound by MultiCategorySettingsDialog.makeSettings
+		keycode = evt.GetKeyCode()
+		mods = evt.GetModifiers()
+		if keycode == wx.WXK_F5 and mods in (wx.MOD_NONE, wx.MOD_CONTROL):
+			currCat = self.currentCategory
+			restrictDualNodeTo = None
+			if mods == wx.MOD_NONE:
+				if isinstance(currCat, StartCriteriaPanel):
+					restrictDualNodeTo = "start"
+				elif isinstance(currCat, EndCriteriaPanel):
+					restrictDualNodeTo = "end"
+			currCat.updateData()
+			testCriteria(self.context, restrictDualNodeTo=restrictDualNodeTo)
+			return
+		super().onCharHook(evt)
+	
+	def onConvertToDual(self, evt):
+		convertToDualNode(self.context)
+		self.EndModal(wx.ID_CONVERT)
+	
+	def onConvertToSingle(self, evt):
+		if gui.messageBox(
+			_(
+				#Translators: A confirmation prompt on the Criteria Set editor
+				"""This will delete your End Criteria choices.
 
-	def onTestCriteria(self, evt):
-		self.currentCategory.updateData()
-		testCriteria(self.context)
+Do you want to proceed?"""
+			),
+			# Translators: The title of a dialog on the Criteria Set editor
+			caption=_("Convert to simple zone (one set of criteria)"),
+			style=wx.ICON_WARNING | wx.YES_NO | wx.NO_DEFAULT
+		) != wx.YES:
+			return
+		convertToSingleNode(self.context)
+		self.EndModal(wx.ID_CONVERT)
 	
 	def _saveAllPanels(self):
 		super()._saveAllPanels()
+		
+		critData = self.getData()
+		ruleData = self.context["data"]["rule"]
+		
+		if set(critData.get("selector", {}).keys()) == {"start", "end"} and (
+			any(
+				key == "mutation" and value
+				for key, value in critData.get("properties", {}).items()
+			) or any(
+				key == "mutation" and value
+				for key, value in ruleData.get("properties", {}).items()
+			)
+		):
+			if gui.messageBox(
+				# Translators: A warning message on the Criteria editor
+				_(
+					'''The "Transform" property is not supported with free zones (two sets of criteria).
+
+Do you want to proceed anyway?
+'''
+				),
+				# Translators: The title of a message dialog
+				caption=_("Warning"),
+				style=wx.ICON_WARNING | wx.YES_NO | wx.CANCEL | wx.NO_DEFAULT
+			) != wx.YES:
+				raise ValidationError()  # Cancels closing of the dialog
+		
 		if createMissingSubModule(self.context, self.getData(), self) is False:
 			raise ValidationError()  # Cancels closing of the dialog
 
 
 def show(context, parent=None):
 	from .. import showContextualDialog
-	return showContextualDialog(CriteriaEditorDialog, context, parent)
+	while True:
+		res = showContextualDialog(
+			CriteriaEditorDialog,
+			context,
+			parent,
+			dualNode=isDualNode(context),
+		)
+		if res != wx.ID_CONVERT:
+			break
+	return res == wx.ID_OK

--- a/addon/globalPlugins/webAccess/gui/rule/editor.py
+++ b/addon/globalPlugins/webAccess/gui/rule/editor.py
@@ -220,7 +220,7 @@ class GeneralPanel(RuleEditorTreeContextualPanel):
 		gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
 
 		row += 1
-		# Translator: The label for a field on the Rule editor
+		# Translators: The label for a field on the Rule editor
 		item = wx.StaticText(self, label=_("Technical n&otes:"))
 		gbSizer.Add(item, pos=(row, 0))
 		item = self.commentText = wx.TextCtrl(self, style=wx.TE_MULTILINE | wx.TE_RICH)
@@ -318,6 +318,7 @@ class GeneralPanel(RuleEditorTreeContextualPanel):
 			gui.messageBox(
 				# Translators: Error message when no type is chosen before saving the rule
 				message=_("You must choose a type for this rule"),
+				# Translators: The title of a message dialog
 				caption=_("Error"),
 				style=wx.OK | wx.ICON_ERROR,
 				parent=self
@@ -973,6 +974,27 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 		super()._saveAllPanels()
 		context = self.context
 		data = self.getData()
+		
+		if any(
+			set(critData.get("selector", {}).keys()) == {"start", "end"}
+			for critData in data.get("criteria", [])
+		) and any(
+			key == "mutation" and value
+			for key, value in data.get("properties", {}).items()
+		):
+			if gui.messageBox(
+				# Translators: A warning message on the Rule editor
+				_(
+					'''The "Transform" property is not supported with free zones (two sets of criteria).
+
+Do you want to proceed anyway?
+'''
+				),
+				# Translators: The title of a message dialog
+				caption=_("Warning"),
+				style=wx.ICON_WARNING | wx.YES_NO | wx.CANCEL | wx.NO_DEFAULT
+			) != wx.YES:
+				raise ValidationError()  # Cancels closing of the dialog
 		
 		# Remove gesture bindings and properties not supported for the selected Rule Type.
 		# This needs to be done here rather than

--- a/addon/globalPlugins/webAccess/gui/rule/gestures.py
+++ b/addon/globalPlugins/webAccess/gui/rule/gestures.py
@@ -64,8 +64,7 @@ SCOPE_LABELS = {
 class GesturesPanelBase(RuleAwarePanelBase, metaclass=guiHelper.SIPABCMeta):
 	"""ABC for Gestures panels
 	
-	Sub-classes must implement the methods `getData` (inherited from `ContextualSettingsPanel`)
-	and `getRuleType` (inherited from `RuleTypeAware`).
+	Sub-classes must implement the method `getData` (inherited from `ContextualSettingsPanel`).
 	
 	Known sub-classes:
 	 - `criteriaEditor.GesturesPanel`

--- a/addon/globalPlugins/webAccess/nodeHandler.py
+++ b/addon/globalPlugins/webAccess/nodeHandler.py
@@ -286,7 +286,6 @@ class NodeManager(baseObject.AutoPropertyObject):
 			self.updating = False
 			self._ready = False
 			if debug:
-				# @@@
 				log.info("NodeManager.update: ")
 			return False
 		self.identifier = time.time()
@@ -390,7 +389,7 @@ class NodeManager(baseObject.AutoPropertyObject):
 						span = (prev[0], span[1]) 
 					elif not(prev[0] <= span[0] and span[1] <= prev[1]):
 						# Neither consecutive nor nested
-						log.warning(f"ControlId double: {controlId} at {prev} and {span}")
+						log.warning(f"ControlId double: {controlId} at {prev} and {span} (role: {node.role})")
 				map[controlId] = span
 			for child in node.children:
 				walk(child)
@@ -892,7 +891,8 @@ class NodeField(TrackedObject):
 		try:
 			(left, top, width, height) = obj.location
 		except Exception:
-			ui.message("Impossible de déplacer la souris à cet emplacement")
+			# Translators: Announced when failing to move the mouse to the Result
+			ui.message(_("Unable to determine mouse target location"))
 			return False
 		x = left + (width // 2)
 		y = top + (height // 2)
@@ -948,6 +948,7 @@ class NodeField(TrackedObject):
 	def __len__(self):
 		return self.size
 
+	# FIXME: Deprecated in favor of getTreeInterceptorText?
 	@property
 	def innerText(self):
 		txt = ""
@@ -981,3 +982,54 @@ class NodeField(TrackedObject):
 			return info.text
 		else:
 			return ""
+
+	def getNodeSpan(self, other):
+		"""Shortest sequence of nodes covering exactly the given range
+		
+		This is used to compute root nodes and excluded nodes when
+		contextParent mentions a free zone.
+		"""
+		start = self.offset
+		end = other.offset + other.size
+		assert start < end
+		
+		seq = []
+		parent = self.parent
+		while True:
+			parentStart = parent.offset
+			parentEnd = parentStart + parent.size
+			if parentStart <= start and end <= parentEnd:
+				break
+			else:
+				parent = parent.parent
+		
+		head, tail = parent._addContainedNodes(seq, start, end)
+		while head is not None:
+			headEnd = head.offset + head.size
+			head, none = head._addContainedNodes(seq, start, headEnd)
+			assert none is None
+		while tail is not None:
+			tailStart = tail.offset
+			none, tail = tail._addContainedNodes(seq, tailStart, end)
+			assert none is None
+		return seq
+
+	def _addContainedNodes(self, seq, start: int, end: int):
+		"""Helper for getNodeSpan
+		
+		Returns the first and last children partially covering the
+		specified range, and add all children in between to seq.
+		"""
+		head = tail = None
+		for child in self.children:
+			childStart = child.offset
+			childEnd = childStart + child.size
+			atLeastHead = start <= childStart <= end
+			atLeastTail = start <= childEnd <= end
+			if atLeastHead and atLeastTail:
+				seq.append(child)
+			elif atLeastHead:
+				head = child
+			elif atLeastTail:
+				tail = child
+		return head, tail

--- a/addon/globalPlugins/webAccess/ruleHandler/__init__.py
+++ b/addon/globalPlugins/webAccess/ruleHandler/__init__.py
@@ -49,14 +49,16 @@ import browseMode
 import controlTypes
 import inputCore
 from logHandler import log
+import mouseHandler
 import queueHandler
 import scriptHandler
 import speech
 import textInfos
-import textInfos.offsets
+from textInfos.offsets import Offsets, OffsetsTextInfo
 import ui
 from core import callLater
 from garbageHandler import TrackedObject
+import winUser
 
 from .. import nodeHandler
 from ..utils import logException
@@ -72,9 +74,10 @@ from .properties import RuleProperties, CriteriaProperties
 
 
 if sys.version_info[1] < 9:
-    from typing import Mapping, Sequence
+    from typing import Mapping, Sequence, Tuple
 else:
     from collections.abc import Mapping, Sequence
+    Tuple = tuple
 
 
 addonHandler.initTranslation()
@@ -160,12 +163,6 @@ class RuleManager(ScriptableObject):
 		if root is not self:
 			return root.nodeManager
 		return self._nodeManager() if self._nodeManager else None
-	
-	def _get_parentNode(self):
-		parentZone = self.parentZone
-		if parentZone is not None:
-			return parentZone.result.Node
-		return self.nodeManager.mainNode
 	
 	def _get_parentRuleManager(self):
 		try:
@@ -425,6 +422,14 @@ class RuleManager(ScriptableObject):
 			return False
 		return True
 
+	def checkReady(self):
+		ready = self.isReady
+		if not ready:
+			playWebAccessSound("keyError")
+			# Translators: Reported when attempting an action while WebAccess is not ready
+			ui.message(_("Not ready"))
+		return ready
+
 	def terminate(self):
 		self._ready = False
 		self._webModule = None
@@ -498,7 +503,7 @@ class RuleManager(ScriptableObject):
 			self._allResults.extend(self._results)
 			
 			for result in self._results:
-				if not (hasattr(result, "node") and result.properties.mutation):
+				if not (isinstance(result, SingleNodeResult) and result.properties.mutation):
 					continue
 				controlId = result.node.controlIdentifier
 				entry = self._mutatedControlsById.get(controlId)
@@ -564,7 +569,7 @@ class RuleManager(ScriptableObject):
 				if result.properties.autoAction:
 					controlIdentifier = result.node.controlIdentifier
 					# check only 100 first characters
-					text = result.node.getTreeInterceptorText()[:100]
+					text = result.getText()[:100]
 					autoActionName = result.properties.autoAction
 					func = getattr(result, "script_%s" % autoActionName)
 					lastText = self.triggeredIdentifiers.get(controlIdentifier)
@@ -1031,7 +1036,7 @@ class CustomActionDispatcher(object):
 
 
 class Result(ScriptableObject):
-
+	
 	def __init__(self, criteria, context, index):
 		super().__init__()
 		self._criteria = weakref.ref(criteria)
@@ -1065,24 +1070,36 @@ class Result(ScriptableObject):
 			else:
 				self.bindSpecialGesture(gestureId, scope, action)
 	
+	def __bool__(self):
+		return bool(self.rule)
+	
+	def __lt__(self, other):
+		try:
+			return self.startOffset < other.startOffset
+		except AttributeError as e:
+			raise TypeError(f"'<' not supported between instances of '{type(self)}' and '{type(other)}'") from e
+	
 	def __repr__(self):
 		try:
 			return f"<{type(self).__name__} of {self.rule.name!r} at {self.startOffset, self.endOffset}>"
 		except Exception:
 			return super().__repr__()
-
+	
 	def _get_criteria(self):
 		return self._criteria()
-
+	
 	def _get_label(self):
 		return self.properties.customName or self.rule.name
-
+	
 	def _get_name(self):
 		return self.rule.name
-
+	
 	def _get_rule(self):
 		return self._rule()
-
+	
+	def _get_ti(self):
+		return self.rule.ruleManager.nodeManager.treeInterceptor
+	
 	def _get_value(self):
 		customValue = self.properties.customValue
 		if customValue:
@@ -1095,15 +1112,93 @@ class Result(ScriptableObject):
 	def _get_endOffset(self):
 		raise NotImplementedError
 
-	def script_moveto(self, gesture):
-		raise NotImplementedError
+	def script_moveto(self, gesture, fromQuickNav=False, fromSpeak=False):
+		rule = self.rule
+		if not rule.ruleManager.checkReady():
+			return
+		reason = nodeHandler.REASON_FOCUS
+		if not fromQuickNav:
+			reason = nodeHandler.REASON_SHORTCUT
+		if fromSpeak:
+			# Translators: Speak rule name on "Move to" action
+			speech.speakMessage(_("Move to {ruleName}").format(
+				ruleName=self.label)
+			)
+		elif self.properties.sayName:
+			speech.speakMessage(self.label)
+		treeInterceptor = self.ti
+		if not treeInterceptor or not treeInterceptor.isReady:
+			return
+		treeInterceptor.passThrough = self.properties.formMode
+		browseMode.reportPassThrough.last = treeInterceptor.passThrough
+		if self.zone:
+			rule.ruleManager.zone = self.zone
+			# Ensure the focus does not remain on a control out of the zone
+			treeInterceptor.rootNVDAObject.setFocus()
+		else:
+			for result in reversed(rule.ruleManager.getResults()):
+				zone = result.zone
+				if zone is None:
+					continue
+				if zone.containsResult(self):
+					rule.ruleManager.zone = zone
+					break
+			else:
+				rule.ruleManager._set_zone(rule.ruleManager.parentZone, force=True)
+		self.moveto()
+		# Refetch the position in case some dynamic content has shrunk as we left it.
+		info = treeInterceptor.selection.copy()
+		if not treeInterceptor.passThrough:
+			info.expand(textInfos.UNIT_LINE)
+			speech.speakTextInfo(
+				info,
+				unit=textInfos.UNIT_LINE,
+				reason=controlTypes.OutputReason.CARET
+			)
+			return
+		focusObject = api.getFocusObject()
+		try:
+			resultObject = self.getTextInfo().NVDAObjectAtStart
+		except Exception:
+			resultObject = None
+		if resultObject == focusObject and focusObject is not None:
+			focusObject.reportFocus()
 
-	def script_sayall(self, gesture):
-		raise NotImplementedError
-
+	def script_sayall(self, gesture, fromQuickNav=False):
+		speech.cancelSpeech()
+		if self.properties.sayName:
+			speech.speakMessage(self.label)
+		treeInterceptor = self.ti
+		speechMode = speech.getState().speechMode
+		try:
+			speech.setSpeechMode(speech.SpeechMode.off)
+			treeInterceptor.passThrough = False
+			browseMode.reportPassThrough.last = treeInterceptor.passThrough
+			self.select()  # FIXME: Shouldn't we move instead?
+			html.speakLine()
+			api.processPendingEvents()
+		except Exception:
+			log.exception("Error during script_sayall")
+			return
+		finally:
+			speech.setSpeechMode(speechMode)
+		speech.sayAll.SayAllHandler.readText(
+			speech.sayAll.CURSOR.CARET
+		)
+	
 	def script_activate(self, gesture):
-		raise NotImplementedError
-
+		rule = self.rule
+		if not rule.ruleManager.checkReady():
+			return
+		treeInterceptor = self.ti
+		if self.properties.sayName:
+			speech.speakMessage(self.label)
+		self.activate()
+		time.sleep(0.1)
+		api.processPendingEvents()
+		treeInterceptor.passThrough = self.properties.formMode
+		browseMode.reportPassThrough.last = treeInterceptor.passThrough
+	
 	def script_speak(self, gesture):
 		repeat = scriptHandler.getLastScriptRepeatCount() if gesture is not None else 0
 		if repeat == 0:
@@ -1115,18 +1210,17 @@ class Result(ScriptableObject):
 			wx.CallAfter(ui.message, msg)
 		else:
 			self.script_moveto(None, fromSpeak=True)
-
+	
 	def script_mouseMove(self, gesture):
-		raise NotImplementedError
-
-	def __bool__(self):
-		raise NotImplementedError
-
-	def __lt__(self, other):
-		try:
-			return self.startOffset < other.startOffset
-		except AttributeError as e:
-			raise TypeError(f"'<' not supported between instances of '{type(self)}' and '{type(other)}'") from e
+		rule = self.rule
+		criteria = self.criteria
+		if self.properties.sayName:
+			speech.speakMessage(self.label)
+		treeInterceptor = self.ti
+		treeInterceptor.passThrough = self.properties.formMode
+		browseMode.reportPassThrough.last = treeInterceptor.passThrough
+		self.select()
+		self.mouseMove()
 	
 	def bindSpecialGesture(self, gestureId, scope, action):
 		try:
@@ -1158,13 +1252,16 @@ class Result(ScriptableObject):
 			except KeyError:
 				continue
 	
+	def activate(self):
+		self.ti._activatePosition(info=self.getTextInfo())
+	
 	def containsNode(self, node):
 		offset = node.offset
 		return self.startOffset <= offset and self.endOffset >= offset + node.size
-
+	
 	def containsResult(self, result):
 		return self.startOffset <= result.startOffset and self.endOffset >= result.endOffset
-
+	
 	def getDisplayString(self):
 		return " ".join(
 			[self.name]
@@ -1173,6 +1270,35 @@ class Result(ScriptableObject):
 				for identifier in list(self._gestureMap.keys())
 			]
 		)
+	
+	def getText(self):
+		return self.getTextInfo().text
+	
+	def getTextInfo(self):
+		return self.ti.makeTextInfo(
+			textInfos.offsets.Offsets(self.startOffset, self.endOffset)
+		)
+	
+	def mouseMove(self):
+		obj = self.getTextInfo().NVDAObjectAtStart
+		try:
+			(left, top, width, height) = obj.location
+		except Exception:
+			# Translators: Announced when failing to move the mouse to the Result
+			ui.message(_("Unable to determine mouse target location"))
+			return
+		x = left + (width // 2)
+		y = top + (height // 2)
+		winUser.setCursorPos(x, y)
+		mouseHandler.executeMouseMoveEvent(x, y)
+	
+	def moveto(self):
+		info = self.getTextInfo()
+		info.collapse()
+		self.ti.selection = info
+	
+	def select(self):
+		self.ti.selection = self.getTextInfo()
 
 
 class SingleNodeResult(Result):
@@ -1185,7 +1311,7 @@ class SingleNodeResult(Result):
 		return self._node()
 
 	def _get_value(self):
-		return self.properties.customValue or self.node.getTreeInterceptorText()
+		return self.properties.customValue or self.getText()
 
 	def _get_startOffset(self):
 		return self.node.offset
@@ -1194,147 +1320,33 @@ class SingleNodeResult(Result):
 		node = self.node
 		return node.offset + node.size
 
-	def script_moveto(self, gesture, fromQuickNav=False, fromSpeak=False):
-		if self.node is None or self.node.nodeManager is None:
-			return
-		rule = self.rule
-		reason = nodeHandler.REASON_FOCUS
-		if not fromQuickNav:
-			reason = nodeHandler.REASON_SHORTCUT
-		if fromSpeak:
-			# Translators: Speak rule name on "Move to" action
-			speech.speakMessage(_("Move to {ruleName}").format(
-				ruleName=self.label)
-			)
-		elif self.properties.sayName:
-			speech.speakMessage(self.label)
-		treeInterceptor = self.rule.ruleManager.nodeManager.treeInterceptor
-		if not treeInterceptor or not treeInterceptor.isReady:
-			return
-		treeInterceptor.passThrough = self.properties.formMode
-		browseMode.reportPassThrough.last = treeInterceptor.passThrough
-		if self.zone:
-			rule.ruleManager.zone = self.zone
-			# Ensure the focus does not remain on a control out of the zone
-			treeInterceptor.rootNVDAObject.setFocus()
-		else:
-			for result in reversed(rule.ruleManager.getResults()):
-				zone = result.zone
-				if zone is None:
-					continue
-				if zone.containsResult(self):
-					rule.ruleManager.zone = zone
-					break
-			else:
-				rule.ruleManager._set_zone(rule.ruleManager.parentZone, force=True)
-		offset = self.startOffset
-		info = treeInterceptor.makeTextInfo(textInfos.offsets.Offsets(offset, offset))
-		treeInterceptor.selection = info
-		# Refetch the position in case some dynamic content has shrunk as we left it.
-		info = treeInterceptor.selection.copy()
-		if not treeInterceptor.passThrough:
-			info.expand(textInfos.UNIT_LINE)
-			speech.speakTextInfo(
-				info,
-				unit=textInfos.UNIT_LINE,
-				reason=controlTypes.OutputReason.CARET
-			)
-			return
-		focusObject = api.getFocusObject()
-		try:
-			nodeObject = self.node.getNVDAObject()
-		except Exception:
-			nodeObject = None
-		if nodeObject == focusObject and focusObject is not None:
-			focusObject.reportFocus()
 
-	def script_sayall(self, gesture, fromQuickNav=False):
-		speech.cancelSpeech()
-		if self.properties.sayName:
-			speech.speakMessage(self.label)
-		treeInterceptor = html.getTreeInterceptor()
-		if not treeInterceptor:
-			return
-		speechMode = speech.getState().speechMode
-		try:
-			speech.setSpeechMode(speech.SpeechMode.off)
-			treeInterceptor.passThrough = False
-			browseMode.reportPassThrough.last = treeInterceptor.passThrough
-			self.node.moveto()
-			html.speakLine()
-			api.processPendingEvents()
-		except Exception:
-			log.exception("Error during script_sayall")
-			return
-		finally:
-			speech.setSpeechMode(speechMode)
-		speech.sayAll.SayAllHandler.readText(
-			speech.sayAll.CURSOR.CARET
-		)
+class DualNodeResult(SingleNodeResult):
+	
+	def __init__(self, criteria, startNode, endNode, context, index):
+		self._endNode = weakref.ref(endNode)
+		super().__init__(criteria, startNode, context, index)
+	
+	def _get_endOffset(self):
+		node = self.endNode
+		return node.offset + node.size
+	
+	def _get_endNode(self):
+		return self._endNode()
+	
 
-	def script_activate(self, gesture):
-		if self.node is None or self.node.nodeManager is None:
-			return
-		if not self.rule.ruleManager.isReady :
-			log.info ("not ready")
-			return
-		treeInterceptor = self.node.nodeManager.treeInterceptor
-		if self.properties.sayName:
-			speech.speakMessage(self.label)
-		self.node.activate()
-		time.sleep(0.1)
-		api.processPendingEvents ()
-		if not treeInterceptor:
-			return
-		treeInterceptor.passThrough = self.properties.formMode
-		browseMode.reportPassThrough.last = treeInterceptor.passThrough
-
-	def script_mouseMove(self, gesture):
-		rule = self.rule
-		criteria = self.criteria
-		if self.properties.sayName:
-			speech.speakMessage(self.label)
-		treeInterceptor = html.getTreeInterceptor()
-		if not treeInterceptor:
-			return
-		treeInterceptor.passThrough = self.properties.formMode
-		browseMode.reportPassThrough.last = treeInterceptor.passThrough
-		self.node.mouseMove()
-
-	def getTextInfo(self):
-		return self.node.getTextInfo()
-
-	def __bool__(self):
-		return bool(self.node)
-
-	def containsNode(self, node):
-		return node in self.node
-
-	def getTitle(self):
-		return self.label + " - " + self.node.innerText
-
-
-class Criteria(ScriptableObject):
-
-	def __init__(self, rule, data):
+class Selector(AutoPropertyObject):
+	
+	def __init__(self, criteria, data):
 		super().__init__()
-		self._rule = weakref.ref(rule)
-		self.properties = CriteriaProperties(self)
+		self._criteria = weakref.ref(criteria)
 		self.load(data)
-
-	def _get_layer(self):
-		return self.rule.layer
-
-	def _get_rule(self):
-		return self._rule()
-
-	def _get_ruleManager(self):
-		return self.rule.ruleManager
-
+	
+	def _get_criteria(self):
+		return self._criteria()
+	
 	def load(self, data):
 		data = data.copy()
-		self.name = data.pop("name", None)
-		self.comment = data.pop("comment", None)
 		self.contextPageTitle = data.pop("contextPageTitle", None)
 		self.contextPageType = data.pop("contextPageType", None)
 		self.contextParent = data.pop("contextParent", None)
@@ -1348,13 +1360,6 @@ class Criteria(ScriptableObject):
 		self.url = data.pop("url", None)
 		self.relativePath = data.pop("relativePath", None)
 		self.index = data.pop("index", None)
-		self.gestures = {
-			gestureId: (GestureScope(scopeName), action)
-			for gestureId, (scopeName, action)
-			in data.pop("gestures", {}).items()
-		}
-		gesturesMap = {}
-		self.properties.load(data.pop("properties", {}))
 		if data:
 			raise ValueError(
 				"Unexpected attribute"
@@ -1366,16 +1371,14 @@ class Criteria(ScriptableObject):
 	def dump(self):
 		data = {}
 
-		def setIfNotDefault(key, value, default=None):
+		def setIfNotDefault(key: str, value: Any, default: Any = None):
 			if value != default:
 				data[key] = value
 
-		def setIfNotNoneOrEmptyString(key, value):
+		def setIfNotNoneOrEmptyString(key: str, value: str):
 			if value and value.strip():
 				data[key] = value
 
-		setIfNotNoneOrEmptyString("name", self.name)
-		setIfNotNoneOrEmptyString("comment", self.comment)
 		setIfNotNoneOrEmptyString("contextPageTitle", self.contextPageTitle)
 		setIfNotNoneOrEmptyString("contextPageType", self.contextPageType)
 		setIfNotNoneOrEmptyString("contextParent", self.contextParent)
@@ -1389,15 +1392,9 @@ class Criteria(ScriptableObject):
 		setIfNotNoneOrEmptyString("url", self.url)
 		setIfNotNoneOrEmptyString("relativePath", self.relativePath)
 		setIfNotDefault("index", self.index)
-		gestures = {
-			grestureId: (scope.value, actionId)
-			for gestureId, (scope, actionId) in self.gestures
-		}
-		setIfNotDefault("gestures", gestures, {})
-		setIfNotDefault("properties", self.properties.dump(), {})
 
 		return data
-
+	
 	def checkContextPageTitle(self):
 		"""
 		Check whether the current page satisfies `contextPageTitle`.
@@ -1420,11 +1417,11 @@ class Criteria(ScriptableObject):
 			expr = expr[1:]
 		# TODO: contextPageTitle: Handle '1:' and '2:' prefixes
 		# TODO: contextPageTitle: Handle '*' partial match
-		candidate = self.rule.ruleManager._getPageTitle()
+		candidate = self.criteria.rule.ruleManager._getPageTitle()
 		if expr == candidate:
 			return not exclude
 		return exclude
-
+	
 	def checkContextPageType(self):
 		"""
 		Check whether the current page satisfies `contextPageTitle`.
@@ -1444,15 +1441,16 @@ class Criteria(ScriptableObject):
 			for name in expr.split("|"):
 				if not name.strip():
 					continue
-				rule = self.ruleManager.getRule(name, layer=self.layer)
+				rule = self.criteria.rule
+				cptRule = rule.ruleManager.getRule(name, layer=rule.layer)
 				if rule is None:
 					log.error((
 						"In rule \"{rule}\".contextPageType: "
 						"Rule not found: \"{pageType}\""
-					).format(rule=self.rule.name, pageType=name))
+					).format(rule=rule.name, pageType=name))
 					return False
 
-				results = rule.getResults()
+				results = cptRule.getResults()
 				if results:
 					nodes = [result.node for result in results]
 					if exclude:
@@ -1466,9 +1464,20 @@ class Criteria(ScriptableObject):
 				return False
 		return True
 	
-	def iterResults(self):
-		t = logTimeStart()
-		rule = self.rule
+	def iterMatches(self) -> Tuple["Node", textInfos.offsets.Offsets]:
+		
+		def iterResultsNodes(results):
+			for result in results:
+				if isinstance(result, DualNodeResult):
+					yield from result.node.getNodeSpan(result.endNode)
+				elif isinstance(result, SingleNodeResult):
+					yield result.node
+				else:
+					log.warning(f"Not supported in contextParent: {result}")
+		
+		criteria = self.criteria
+		properties = criteria.properties
+		rule = criteria.rule
 		mgr = rule.ruleManager
 		text = self.text
 		if not self.checkContextPageTitle():
@@ -1493,7 +1502,7 @@ class Criteria(ScriptableObject):
 				name = name.strip()
 				if not name:
 					continue
-				parentRule = mgr.getRule(name, layer=self.layer)
+				parentRule = mgr.getRule(name, layer=rule.layer)
 				if parentRule is None:
 					log.error(
 						'In rule "{rule}", alternative "{alternative}" .contextParent: '
@@ -1511,7 +1520,7 @@ class Criteria(ScriptableObject):
 				else:
 					multipleContext = False
 				if results:
-					nodes = (result.node for result in results)
+					nodes = iterResultsNodes(results)
 					if exclude:
 						excludedNodes.update(nodes)
 					else:
@@ -1533,13 +1542,11 @@ class Criteria(ScriptableObject):
 				return
 			rootNodes = newRootNodes
 		kwargs = getSimpleSearchKwargs(self)
-		excludedNodes.update({
-			result.node for result in mgr.subModules._results
-		})
+		excludedNodes.update(iterResultsNodes(mgr.subModules._results))
 		if excludedNodes:
 			kwargs["exclude"] = excludedNodes
 		limit = None
-		if not self.properties.multiple:
+		if not properties.multiple:
 			limit = self.index or 1  # 1-based
 
 		index = 0
@@ -1549,7 +1556,7 @@ class Criteria(ScriptableObject):
 				rootNodes = (parentZone.result.node,)
 			else:
 				rootNodes = (mgr.nodeManager.mainNode,)
-		for root in rootNodes or (parentNode,):
+		for root in rootNodes:
 			rootLimit = limit
 			if multipleContext:
 				index = 0
@@ -1566,13 +1573,109 @@ class Criteria(ScriptableObject):
 					startOffset=root.offset,
 					endOffset=root.offset + root.size
 				) if root is not mgr.nodeManager.mainNode else None
-				yield rule.createResult(self, node, context, index)
-				if not self.properties.multiple and not multipleContext:
+				yield node, context
+				if not properties.multiple and not multipleContext:
 					return
 
+
+class Criteria(ScriptableObject):
+	
+	def __init__(self, rule, data):
+		super().__init__()
+		self._rule = weakref.ref(rule)
+		self.nodeSelector: Selector = None
+		self.startSelector: Selector = None
+		self.endSelector: Selector = None
+		self.gestures = {}
+		self.properties = CriteriaProperties(self)
+		self.load(data)
+	
+	def _get_rule(self):
+		return self._rule()
+	
+	def load(self, data):
+		data = data.copy()
+		self.name = data.pop("name", None)
+		self.comment = data.pop("comment", None)
+		selector = data.pop("selector", {})
+		rule = self.rule
+		if len(selector) == 2 and "start" in selector and "end" in selector:
+			self.startSelector = Selector(self, selector["start"])
+			self.endSelector = Selector(self, selector["end"])
+		else:
+			self.nodeSelector = Selector(self, selector)
+		self.gestures = {
+			gestureId: (GestureScope(scopeName), action)
+			for gestureId, (scopeName, action)
+			in data.pop("gestures", {}).items()
+		}
+		self.properties.load(data.pop("properties", {}))
+		if data:
+			raise ValueError(
+				"Unexpected attribute"
+				+ ("s" if len(data) > 1 else "")
+				+ ": "
+				+ ", ".join(list(data.keys()))
+			)
+	
+	def dump(self):
+		data = {}
+
+		def setIfNotDefault(key, value, default=None):
+			if value != default:
+				data[key] = value
+
+		def setIfNotNoneOrEmptyString(key, value):
+			if value and value.strip():
+				data[key] = value
+
+		setIfNotNoneOrEmptyString("name", self.name)
+		setIfNotNoneOrEmptyString("comment", self.comment)
+		if self.nodeSelector is not None:
+			data["selector"] = self.nodeSelector.dump()
+		else:
+			data["selector"] = {
+				"start": self.startSelector.dump(),
+				"end": self.endSelector.dump(),
+			}
+		gestures = {
+			grestureId: (scope.value, actionId)
+			for gestureId, (scope, actionId) in self.gestures
+		}
+		setIfNotDefault("gestures", gestures, {})
+		setIfNotDefault("properties", self.properties.dump(), {})
+
+		return data
+	
+	def iterResults(self):
+		rule = self.rule
+		if self.nodeSelector is not None:
+			for index, (node, context) in enumerate(self.nodeSelector.iterMatches()):
+				yield rule.createResult(self, node, context, index)
+			return
+		starts = tuple(self.startSelector.iterMatches())
+		ends = tuple(self.endSelector.iterMatches())
+		if len(starts) != len(ends):
+			return
+		matches = tuple(zip(starts, ends))
+		if any(
+			start[0].offset > end[0].offset
+			for (start, end) in matches
+		):
+			return
+		for index, (start, end) in enumerate(matches):
+			startNode, startContext = start
+			endNode, endContext = end
+			context = None
+			if startContext is not None:
+				context = textInfos.offsets.Offsets(startContext.startOffset, startContext.endOffset)
+				if endContext is not None:
+					context.endOffset = endContext.endOffset
+			yield rule.createResult(self, (startNode, endNode), context, index)			
+	
 	def script_notFound(self, gesture):
 		speech.speakMessage(_("{criteriaName} not found").format(
-			criteriaName=self.label)
+			criteriaName=self.name)
 		)
 
 
@@ -1645,8 +1748,12 @@ class Rule(ScriptableObject):
 			).items()
 		})
 
-	def createResult(self, criteria, node, context, index):
-		return SingleNodeResult(criteria, node, context, index)
+	def createResult(self, criteria, position, context, index):
+		if isinstance(position, tuple):
+			assert len(position) == 2
+			return DualNodeResult(criteria, *position, context, index)
+		else:
+			return SingleNodeResult(criteria, position, context, index)
 
 	def resetResults(self):
 		self._results = None
@@ -1895,7 +2002,7 @@ class Zone(AutoPropertyObject):
 			return True
 		try:
 			# Result index is 1-based
-			self.result = self.getRule().getResults()[self.index - 1]
+			self.result = self.getRule().getResults()[self.index]
 		except IndexError:
 			self._result = None
 			return False

--- a/addon/globalPlugins/webAccess/webModuleHandler/dataRecovery/__init__.py
+++ b/addon/globalPlugins/webAccess/webModuleHandler/dataRecovery/__init__.py
@@ -85,6 +85,9 @@ def recover(data):
 	if formatVersion < version.parse("0.11-dev"):
 		recoverFrom_0_10_to_0_11(data)
 		formatVersion = version.parse(data["formatVersion"])
+	if formatVersion < version.parse("0.12-dev"):
+		recoverFrom_0_11_to_0_12(data)
+		formatVersion = version.parse(data["formatVersion"])
 	
 	from ..webModule import WebModule
 	if formatVersion > WebModule.FORMAT_VERSION:
@@ -565,3 +568,21 @@ def recoverFrom_0_10_to_0_11(data):
 			process(scope, crit)
 	
 	data["formatVersion"] = "0.11-dev"
+
+
+def recoverFrom_0_11_to_0_12(data):
+	
+	for rule in data.get("Rules", {}).values():
+		alternatives = []
+		for crit in rule.get("criteria", []):
+			orig = crit.copy()
+			new = {}
+			for key in ("name", "comment", "gestures", "properties"):
+				if key in orig:
+					new[key] = orig.pop(key)
+			new["selector"] = orig
+			alternatives.append(new)
+		if alternatives:
+			rule["criteria"] = alternatives
+	
+	data["formatVersion"] = "0.12-dev"

--- a/addon/globalPlugins/webAccess/webModuleHandler/webModule.py
+++ b/addon/globalPlugins/webAccess/webModuleHandler/webModule.py
@@ -99,9 +99,9 @@ class WebModuleDataLayer(baseObject.AutoPropertyObject):
 
 class WebModule(baseObject.ScriptableObject):
 
-	API_VERSION = version.parse("0.6")
+	API_VERSION = version.parse("0.7")
 
-	FORMAT_VERSION_STR = "0.11-dev"
+	FORMAT_VERSION_STR = "0.12-dev"
 	FORMAT_VERSION = version.parse(FORMAT_VERSION_STR)
 
 	def __init__(self):

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -21,8 +21,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2025-02-12 16:19+0100\n"
-"PO-Revision-Date: 2025-02-12 16:22+0100\n"
+"POT-Creation-Date: 2025-02-14 19:06+0100\n"
+"PO-Revision-Date: 2025-02-14 19:07+0100\n"
 "Last-Translator: Julien Cochuyt <JulienCochuyt@users.noreply.github.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -37,6 +37,12 @@ msgstr ""
 "X-Poedit-Bookmarks: -1,2,-1,-1,-1,-1,-1,-1,-1,-1\n"
 "X-Poedit-SearchPath-0: .\n"
 
+#. Translators: Announced when failing to move the mouse to the Result
+#: addon\globalPlugins\webAccess\nodeHandler.py:895
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1288
+msgid "Unable to determine mouse target location"
+msgstr "Impossible de déterminer l'emplacement cible du pointeur de souris"
+
 #: addon\globalPlugins\webAccess\overlay.py:534
 msgid "Zone border"
 msgstr "Bordure de zone"
@@ -45,13 +51,13 @@ msgstr "Bordure de zone"
 #: addon\globalPlugins\webAccess\overlay.py:538
 #: addon\globalPlugins\webAccess\overlay.py:859
 #: addon\globalPlugins\webAccess\overlay.py:880
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:841
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:846
 msgid "Press escape to cancel zone restriction."
 msgstr "Appuyez sur échappement pour ne plus être restreint à la zone."
 
 #. Translators: Complement to quickNav error message in zone.
 #: addon\globalPlugins\webAccess\overlay.py:856
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:838
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:843
 msgid "in this zone."
 msgstr "dans cette zone."
 
@@ -414,211 +420,247 @@ msgstr "{field} : {value}"
 #. Translators: A mention on the Criteria summary report
 #. Translator: A selection value for the Context field on the Criteria editor
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:178
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:436
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:560
 msgid "General - Applies to the whole web module"
 msgstr "Général - S'applique à l'ensemble du module web"
 
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:186
+msgid "Start:"
+msgstr "Début :"
+
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:187
+msgid "End:"
+msgstr "Fin :"
+
 #. Translators: A mention on the Criteria Summary report
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:215
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:248
+msgid "No criteria"
+msgstr "Pas de critère"
+
+#. Translators: A mention on the Criteria Summary report
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:264
 #, python-brace-format
 msgid "{indent}{field}: {value}"
 msgstr "{indent}{field} : {value}"
 
 #. Translators: The label for a section on the Criteria Summary report
 #. Translators: The label for a section on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:223
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:272
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:125
 #, python-brace-format
 msgid "{section}:"
 msgstr "{section} :"
 
-#. Translators: A mention on the Criteria Summary report
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:232
-msgid "No criteria"
-msgstr "Pas de critère"
+#. Translators: The title of a dialog in the Criteria Set editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:294
+msgid "Start Criteria test"
+msgstr "Test des critères de début"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:259
+#. Translators: The title of a dialog in the Criteria Set editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:296
+msgid "End Criteria test"
+msgstr "Test des critères de fin"
+
+#. Translators: The title of a dialog in the Criteria Set editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:302
+msgid "Combined Criteria test"
+msgstr "Test des critères combinés"
+
+#. Translators: The title of a dialog in the Criteria Set editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:305
+msgid "Criteria test"
+msgstr "Test des critères"
+
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:325
 msgid "Found 1 result in {:.3f} seconds."
 msgstr "Trouvé 1 résultat en {:.3f} secondes."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:261
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:327
 msgid "Found {} results in {:.3f} seconds."
 msgstr "Trouvé {} résultats en {:.3f} secondes."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:263
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:329
 msgid "No result found on the current page."
 msgstr "Aucun résultat trouvé sur la page actuelle."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:264
-msgid "Criteria test"
-msgstr "Critères d'évaluation"
-
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for the General settings panel.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:277
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:366
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:174
 msgid "General"
 msgstr "Général"
 
 #. Translator: The label for a field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:291
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:380
 msgid "Criteria Set &name:"
 msgstr "Nom du jeu de critères :"
 
 #. Translator: The label for a field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:303
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:393
 msgid "&Sequence order:"
 msgstr "Ordre de &séquence :"
 
 #. Translator: The label for a field on the Criteria editor
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:317
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:407
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:212
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:404
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:405
 msgid "Summar&y:"
 msgstr "&Résumé :"
 
 #. Translator: The label for a field on the Criteria editor
-#. Translator: The label for a field on the Rule editor
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:329
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:419
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:224
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:416
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:417
 msgid "Technical n&otes:"
 msgstr "N&otes techniques :"
 
+#. Translators: The label for a button in the Criteria Editor dialog
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:433
+msgid "Convert to free zone (two sets of criteria)"
+msgstr "Convertir en zone libre (deux jeux de critères)"
+
+#. Translators: The label for a button in the Criteria Editor dialog
+#. Translators: The title of a dialog on the Criteria Set editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:448
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1197
+msgid "Convert to simple zone (one set of criteria)"
+msgstr "Convertir en zone simple (un seul jeu de critères)"
+
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for a category in the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:387
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:372
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:511
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:373
 msgid "Criteria"
 msgstr "Critères"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:393
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:517
 msgctxt "webAccess.ruleCriteria"
 msgid "Page &title:"
 msgstr "&Titre de page :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:395
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:519
 msgctxt "webAccess.ruleCriteria"
 msgid "Page t&ype"
 msgstr "T&ype de page"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:397
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:521
 msgctxt "webAccess.ruleCriteria"
 msgid "&Parent element"
 msgstr "Élément &parent"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:399
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:523
 msgctxt "webAccess.ruleCriteria"
 msgid "&Text:"
 msgstr "&Texte :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:401
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:525
 msgctxt "webAccess.ruleCriteria"
 msgid "&Role:"
 msgstr "&Rôle :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:403
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:527
 msgctxt "webAccess.ruleCriteria"
 msgid "T&ag:"
 msgstr "B&alise :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:405
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:529
 msgctxt "webAccess.ruleCriteria"
 msgid "&ID:"
 msgstr "&ID :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:407
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:531
 msgctxt "webAccess.ruleCriteria"
 msgid "&Class:"
 msgstr "&Classe :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:409
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:533
 msgctxt "webAccess.ruleCriteria"
 msgid "&States:"
 msgstr "État&s :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:411
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:535
 msgctxt "webAccess.ruleCriteria"
 msgid "Ima&ge source:"
 msgstr "Source de l'ima&ge :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:413
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:537
 msgctxt "webAccess.ruleCriteria"
 msgid "Document &URL:"
 msgstr "&URL du document :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:415
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:539
 msgctxt "webAccess.ruleCriteria"
 msgid "R&elative path:"
 msgstr "Ch&emin relatif :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:417
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:541
 msgctxt "webAccess.ruleCriteria"
 msgid "Inde&x:"
 msgstr "Inde&x :"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:431
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:555
 msgid "Context:"
 msgstr "Contexte :"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:438
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:562
 msgid "Page title - Applies only to pages with the given title"
 msgstr "Titre de page - S'applique uniquement aux pages portant le titre donné"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:440
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:564
 msgid "Page type - Applies only to pages with the given type"
 msgstr "Type de page - S'applique uniquement aux pages du type donné"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:442
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:566
 msgid "Parent element - Applies only within the results of another rule"
 msgstr ""
 "Élément parent - S'applique uniquement dans le cadre des résultats d'une "
 "autre règle"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:444
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:568
 msgid "Advanced"
 msgstr "Avancé"
 
 #. Translators: The label for a button in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:611
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:735
 msgid "Test these criteria (F5)"
 msgstr "Tester ces critères (F5)"
 
 #. Translators: Error message when the field doesn't meet the required syntax
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:794
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:823
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:922
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:951
 #, python-brace-format
 msgid "Syntax error in the field \"{field}\""
 msgstr "Erreur de syntaxe dans le champ \"{field}\""
 
+#. Translators: The title of a message dialog
 #. Translators: The title of an error message dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:796
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:810
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:825
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:839
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:856
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:321
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:333
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:362
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:924
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:938
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:953
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:967
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:984
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:322
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:334
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:363
 #: addon\globalPlugins\webAccess\gui\webModule\editor.py:275
 #: addon\globalPlugins\webAccess\gui\webModule\editor.py:289
 #: addon\globalPlugins\webAccess\webModuleHandler\__init__.py:357
@@ -626,38 +668,48 @@ msgid "Error"
 msgstr "Erreur"
 
 #. Translators: Error message when the field doesn't match any known identifier
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:808
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:837
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:936
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:965
 #, python-brace-format
 msgid "Unknown identifier in the field \"{field}\""
 msgstr "Identifiant inconnu dans le champ \"{field}\""
 
 #. Translators: Error message when the index is not positive
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:855
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:983
 msgid "Index, if set, must be a positive integer."
 msgstr "Index, si renseigné, doit être un nombre entier strictement positif."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:875
+#. Translators: The label for a Criteria editor category.
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:996
+msgid "Start Criteria"
+msgstr "Critères de début"
+
+#. Translators: The label for a Criteria editor category.
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1008
+msgid "End Criteria"
+msgstr "Critères de fin"
+
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1027
 msgid "Select a property to override"
 msgstr "Sélectionnez une propriété à surcharger"
 
 #. Translators: The label for a list on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:888
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1040
 msgid "Properties specific to this criteria set"
 msgstr "Propriétés spécifiques à cet ensemble de critères"
 
 #. Translators: A hint stating a list is empty and how to populate it on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:891
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1043
 msgid "None. Press alt+n to override a property."
 msgstr "Aucune. Appuyez sur alt+n pour remplacer une propriété."
 
 #. Translators: A column header in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:893
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1045
 msgid "Rule value"
 msgstr "Valeur de la règle"
 
 #. Translators: The label for a button on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:901
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1053
 msgid "&New"
 msgstr "&Nouveau"
 
@@ -669,11 +721,11 @@ msgstr "&Nouveau"
 #. Translator: The label for a button on the RulesManager dialog.
 #. Translators: The label for a button in the
 #. Web Modules Manager dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:911
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:447
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:655
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:748
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:145
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1063
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:448
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:656
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:749
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:144
 #: addon\globalPlugins\webAccess\gui\rule\manager.py:494
 #: addon\globalPlugins\webAccess\gui\webModule\manager.py:126
 msgid "&Delete"
@@ -681,16 +733,47 @@ msgstr "&Supprimer"
 
 #. Avoid announcing the whole eventual control refresh
 #. Translators: Announced when resetting a property to its default value in the editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:987
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1139
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:313
 #, python-brace-format
 msgid "Reset to {value}"
 msgstr "Réinitialiser à {value}"
 
 #. Translators: The title of the Criteria Editor dialog.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:992
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1144
 msgid "WebAccess Criteria Set editor"
 msgstr "Éditeur de jeux de critères WebAccess"
+
+#. Translators: A confirmation prompt on the Criteria Set editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1192
+msgid ""
+"This will delete your End Criteria choices.\n"
+"\n"
+"Do you want to proceed?"
+msgstr ""
+"Ceci supprimera vos critères de fin\n"
+"\n"
+"Voulez-vous continuer ?"
+
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1222
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:988
+msgid ""
+"The \"Transform\" property is not supported with free zones (two sets of "
+"criteria).\n"
+"\n"
+"Do you want to proceed anyway?\n"
+msgstr ""
+"La propriété \"Transformation\" n'est pas prise en charge pour les zones "
+"libres (deux jeux de critères).\n"
+"\n"
+"Voulez-vous poursuivre néanmoins ?\n"
+
+#. Translators: The title of a message dialog
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1228
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:994
+#: addon\globalPlugins\webAccess\gui\webModule\__init__.py:86
+msgid "Warning"
+msgstr "Avertissement"
 
 #. Translators: The Label for a field on the Rule editor
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:98
@@ -741,17 +824,17 @@ msgid "You must choose a type for this rule"
 msgstr "Vous devez choisir un type pour cette règle"
 
 #. Translators: Error message when no name is entered before saving the rule
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:332
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:333
 msgid "You must choose a name for this rule"
 msgstr "Vous devez choisir un nom pour cette règle"
 
 #. Translators: Error message when another rule with the same name already exists
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:361
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:362
 msgid "There already is another rule with the same name."
 msgstr "Il existe déjà une autre règle portant le même nom."
 
 #. Translators: Label for a control in the Rule Editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:386
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:387
 msgid "&Alternatives"
 msgstr "&Alternatives"
 
@@ -759,10 +842,10 @@ msgstr "&Alternatives"
 #. Translators: New criteria button label
 #. Translators: The label for a button on the Rule Editor dialog
 #. Translators: The label for a button in the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:429
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:662
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:755
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:123
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:430
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:663
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:756
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:122
 msgid "&New..."
 msgstr "&Nouveau..."
 
@@ -771,64 +854,64 @@ msgstr "&Nouveau..."
 #. Translators: The label for a button in the Rule Editor dialog
 #. Translator: The label for a button on the RulesManager dialog.
 #. Translators: The label for a button in the Web Modules Manager dialog
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:438
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:646
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:134
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:439
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:647
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:133
 #: addon\globalPlugins\webAccess\gui\rule\manager.py:486
 #: addon\globalPlugins\webAccess\gui\webModule\manager.py:103
 msgid "&Edit..."
 msgstr "&Modifier..."
 
 #. Translator: A confirmation prompt on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:521
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:522
 msgid "Are you sure you want to delete this alternative?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette alternative ?"
 
 #. Translator: The title for a confirmation prompt on the Rule editor
 #. Translator: The title for a confirmation prompt on the
 #. RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:523
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:524
 #: addon\globalPlugins\webAccess\gui\rule\manager.py:743
 msgid "Confirm Deletion"
 msgstr "Confirmation d'effacement"
 
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:611
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:612
 msgid "Summar&y"
 msgstr "&Résumé"
 
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:628
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:629
 msgid "Technical n&otes"
-msgstr "&Notes techniques"
+msgstr "N&otes techniques"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:931
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:932
 msgid "Sub Module {} - New Rule"
 msgstr "Sous-module {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:934
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:935
 msgid "Root Module {} - New Rule"
 msgstr "Module racine {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:937
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:938
 msgid "Web Module {} - New Rule"
 msgstr "Module web {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:942
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:943
 msgid "Sub Module {} - Edit Rule {}"
 msgstr "Sous-module {} - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:945
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:946
 msgid "Root Module {} - Edit Rule {}"
 msgstr "Module racine - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:948
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:949
 msgid "Web Module {} - Edit Rule {}"
 msgstr "Module web {} - Modifier la règle {}"
 
@@ -908,13 +991,13 @@ msgid "Local scope"
 msgstr "Portée locale"
 
 #. Translators: Displayed when the selected rule type doesn't support input gestures
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:79
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:78
 msgid "The selected Rule Type does not support Input Gestures."
 msgstr ""
 "Le type de règle sélectionné ne prend pas en charge les gestes de commande."
 
 #. Translators: The label for a list on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\gestures.py:102
+#: addon\globalPlugins\webAccess\gui\rule\gestures.py:101
 msgid "&Gestures"
 msgstr "&Gestes"
 
@@ -1153,10 +1236,6 @@ msgstr ""
 "Voulez-vous en faire une copie dans votre répertoire Bloc-notes du "
 "Développeur (scratchpad) ?\n"
 
-#: addon\globalPlugins\webAccess\gui\webModule\__init__.py:86
-msgid "Warning"
-msgstr "Avertissement"
-
 #. Translators: The label for a control mutation.
 #: addon\globalPlugins\webAccess\ruleHandler\controlMutation.py:149
 msgctxt "webAccess.controlMutation"
@@ -1363,88 +1442,89 @@ msgid "Page secondary title"
 msgstr "Titre de page - secondaire"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:86
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:89
 msgctxt "webAccess.action"
 msgid "Move to"
 msgstr "Aller à"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:88
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:91
 msgctxt "webAccess.action"
 msgid "Say all"
 msgstr "Dire tout"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:90
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:93
 msgctxt "webAccess.action"
 msgid "Speak"
 msgstr "Énoncer"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:92
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:95
 msgctxt "webAccess.action"
 msgid "Activate"
 msgstr "Activer"
 
 #. Translators: Action name
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:94
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:97
 msgctxt "webAccess.action"
 msgid "Mouse move"
 msgstr "Déplacer la souris"
 
 #. Translators: Reported when attempting an action while WebAccess is not ready
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:779
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:789
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:430
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:784
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:794
 msgid "Not ready"
 msgstr "Pas encore prêt"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:818
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:823
 msgid "No previous zone"
 msgstr "Pas de zone précédente"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:821
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:826
 msgid "No next zone"
 msgstr "Pas de zone suivante"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:824
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:829
 msgid "No zone"
 msgstr "Pas de zone"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:828
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:833
 msgid "No marker"
 msgstr "Pas de marqueur"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:831
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:836
 msgid "No previous marker"
 msgstr "Pas de marqueur précédent"
 
 #. Translator: Error message in quickNav (page up/down)
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:834
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:839
 msgid "No next marker"
 msgstr "Pas de marqueur suivant"
 
 #. Translators: Speak rule name on "Move to" action
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1206
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1124
 #, python-brace-format
 msgid "Move to {ruleName}"
 msgstr "Aller à {ruleName}"
 
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1574
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1677
 #, python-brace-format
 msgid "{criteriaName} not found"
 msgstr "{criteriaName} non trouvé"
 
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1664
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1771
 #, python-brace-format
 msgid "{ruleName} not found"
 msgstr "{ruleName} introuvable"
 
-#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1669
+#: addon\globalPlugins\webAccess\ruleHandler\__init__.py:1776
 #, python-brace-format
 msgid "{ruleName} not found locally"
 msgstr "{ruleName} introuvable localement"
@@ -1517,8 +1597,8 @@ msgstr "ou"
 msgid "You may, in NVDA Preferences:"
 msgstr "Vous pouvez, dans les paramètres de NVDA :"
 
-#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:426
-#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:437
+#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:429
+#: addon\globalPlugins\webAccess\webModuleHandler\dataRecovery\__init__.py:440
 msgid "Recovered from format version {}"
 msgstr "Récupéré depuis le format de version {}"
 


### PR DESCRIPTION
Fixes #43.

Currently, a zone spans a single document node.
In some cases, it would be useful if they could freely span from a position to another, without this limitation.
It can be obtained by referencing two criteria sets for a single rule alternative.

Proposed changes:
     - Altered signature: Rule.createRule
     - New Result class: DualNodeResult
     - Refactoring: Selector extracted from Criteria (may hold one or two)
     - Support mentioning a free zone in the contextParent criterion
     - Result.index is now 0-based and is Rule-relative (was context-)
     - GUI: Criteria Set Editor: `F5` tests the selected set, `control+F5` tests the combination of both
     - Bump API version to 0.7-dev
     - Bump JSON format version to 0.12-dev

Limitation: The proposed implementation does not support control mutation of free zones. Thus, they cannot be mutated into regions or sections. The user is warned about this limitation when saving in the editors.