### PR TITLE
Simplified Multi-Criteria UI

### DIFF
--- a/addon/globalPlugins/webAccess/gui/__init__.py
+++ b/addon/globalPlugins/webAccess/gui/__init__.py
@@ -434,8 +434,10 @@ class ContextualMultiCategorySettingsDialog(
 			if not getattr(panel.initData, "onPanelActivated", False):
 				panel.initData(context)
 	
-	# Changed from NVDA's MultiCategorySettingsDialog: Use ValidationError instead of ValueError,
-	# in order to not misinterpret a real unintentional ValueError.
+	# Changed from NVDA's MultiCategorySettingsDialog:
+	#  - Use ValidationError instead of ValueError, in order to not
+	#    misinterpret a real unintentional ValueError.
+	#  - Check if the dialog is modal
 	@guarded
 	def onOk(self, evt):
 		try:
@@ -447,8 +449,11 @@ class ContextualMultiCategorySettingsDialog(
 		except Exception:
 			notifyError()
 		else:
-			self.DestroyLater()
-			self.SetReturnCode(wx.ID_OK)
+			if self.IsModal():
+				self.EndModal(wx.ID_OK)
+			else:
+				self.DestroyLater()
+				self.SetReturnCode(wx.ID_OK)
 	
 	def selectPanel(self, panel: ContextualSettingsPanel):
 		index = self.categoryClasses.index(type(panel))
@@ -462,7 +467,7 @@ class ContextualMultiCategorySettingsDialog(
 			and isinstance(panel, ContextualSettingsPanel)
 			and (
 				getattr(panel, "context", None) is not self.context
-				or getattr(panel.initData, "onPanelActivated", False)
+				and not getattr(panel.initData, "onPanelActivated", False)
 			)
 		):
 			panel.initData(self.context)
@@ -470,7 +475,8 @@ class ContextualMultiCategorySettingsDialog(
 	
 	# Changed from NVDA's MultiCategorySettingsDialog: Use ValidationError instead of ValueError,
 	# in order to not misinterpret a real unintentional ValueError.
-	# Additionnaly, this implementation selects the category for the invalid panel.
+	# Additionnaly, this implementation selects the category for the invalid panel, which still needs
+	# to set focus on the relevant control.
 	def _validateAllPanels(self):
 		"""Check if all panels are valid, and can be saved
 		@note: raises ValidationError if a panel is not valid. See c{SettingsPanel.isValid}
@@ -625,7 +631,7 @@ class TreeMultiCategorySettingsDialog(ContextualMultiCategorySettingsDialog):
 				TreeNodeInfo(categoryClass, childrenGetter=childrenGetter, title=categoryClass.title))
 		return categoryClasses
 
-	def _changeCategoryPanel(self, newCatInfos):
+	def _getCategoryPanel(self, newCatInfos):
 		panel = self.catIdToInstanceMap.get(newCatInfos.title, None)
 		if panel:
 			self.context[panel.CATEGORY_PARAMS_CONTEXT_KEY] = newCatInfos.categoryParams
@@ -663,7 +669,7 @@ class TreeMultiCategorySettingsDialog(ContextualMultiCategorySettingsDialog):
 		if oldCat:
 			oldCat.onPanelDeactivated()
 		try:
-			newPanel = self._changeCategoryPanel(newCatInfos)
+			newPanel = self._getCategoryPanel(newCatInfos)
 		except ValueError as e:
 			log.error("Unable to change to category: {}".format(newCatInfos.title), exc_info=e)
 			return
@@ -833,7 +839,7 @@ class HideableChoice:
 		self.enabled = enabled
 
 
-class DropDownWithHideableChoices(wx.ComboBox):
+class DropDownWithHideableChoices(SizeFrugalComboBox):
 
 	def __init__(self, *args, **kwargs):
 		style = kwargs.get("style", 0)

--- a/addon/globalPlugins/webAccess/gui/menu.py
+++ b/addon/globalPlugins/webAccess/gui/menu.py
@@ -141,12 +141,12 @@ class Menu(wx.Menu):
 	def onRuleCreate(self, evt):
 		self.context["new"] = True
 		from .rule.editor import show
-		show(self.context, gui.mainFrame)
+		show(self.context)
 	
 	@guarded
 	def onRulesManager(self, evt):
 		from .rule.manager import show
-		show(self.context, gui.mainFrame)
+		show(self.context)
 	
 	@guarded
 	def onWebModuleCreate(self, evt, webModule=None):

--- a/addon/globalPlugins/webAccess/gui/rule/criteriaEditor.py
+++ b/addon/globalPlugins/webAccess/gui/rule/criteriaEditor.py
@@ -1,4 +1,4 @@
-# globalPlugins/webAccess/gui/rule/criteria.py
+# globalPlugins/webAccess/gui/rule/criteriaEditor.py
 # -*- coding: utf-8 -*-
 
 # This file is part of Web Access for NVDA.
@@ -58,6 +58,7 @@ from .. import (
 	SizeFrugalComboBox,
 	ValidationError,
 	stripAccel,
+	showContextualDialog,
 	stripAccelAndColon,
 )
 from . import createMissingSubModule
@@ -297,7 +298,7 @@ def testCriteria(context, restrictDualNodeTo=None):
 		}[restrictDualNodeTo]
 	else:
 		critData = context["data"]["criteria"].copy()
-		if isDualNode(context):
+		if isDualNode(critData):
 			# Translators: The title of a dialog in the Criteria Set editor
 			caption = _("Combined Criteria test")
 		else:
@@ -330,27 +331,30 @@ def testCriteria(context, restrictDualNodeTo=None):
 	gui.messageBox(message, caption=caption)
 
 
-def isDualNode(context):
-	data = context.get("data", {}).get("criteria", {}).get("selector", {})
-	return set(data.keys()) == {"start", "end"}
+def isDualNode(data):
+	return set(data.get("selector", {}).keys()) == {"start", "end"}
 
 
-def convertToDualNode(context):
-	if isDualNode(context):
+def supportsSimpleMode(data):
+	if any(
+		k in ("gestures", "properties")
+		for k in data.keys()
+	):
+		return False
+	return True
+
+
+def convertToDualNode(data):
+	if isDualNode(data):
 		raise ValueError("This selector is already dual node")
-	data = context.get("data", {}).get("criteria", {}).get("selector", {})
-	selector = {"start": data.copy(), "end": data.copy()}
-	context["data"].setdefault("criteria", {})["selector"] = selector
+	selector = data.get("selector", {})
+	data["selector"] = {"start": selector.copy(), "end": selector.copy()}
 
 
-def convertToSingleNode(context):
-	if not isDualNode(context):
+def convertToSingleNode(data):
+	if not isDualNode(data):
 		raise ValueError("This selector is not dual node")
-	data = context.get("data", {}).get("criteria", {}).get("selector", {})
-	selector = data.pop("start")
-	del data["end"]
-	context["data"].setdefault("criteria", {})["selector"] = selector
-
+	data["selector"] = data["selector"]["start"]
 
 
 class CriteriaEditorPanel(RuleAwarePanelBase):
@@ -430,7 +434,7 @@ class GeneralPanel(CriteriaEditorPanel):
 
 		row += 1
 		# Translators: The label for a button in the Criteria Editor dialog
-		item = wx.Button(self, label=_("Convert to free zone (two sets of criteria)"))
+		item = wx.Button(self, label=_("Convert to free &zone (two sets of criteria)"))
 		item.Bind(wx.EVT_BUTTON, self.Parent.Parent.onConvertToDual)
 		items.append(item)
 		item = gbSizer.Add(item, pos=(row, 0), span=(1, 3), flag=wx.EXPAND)
@@ -471,7 +475,7 @@ class GeneralPanel(CriteriaEditorPanel):
 			index = data.get("criteriaIndex", nbAlternatives + 1)
 			self.sequenceOrderChoice.SetSelection(index)
 		if self.getRuleType() == ruleTypes.ZONE:
-			key = "convert.single" if isDualNode(context) else "convert.dual"
+			key = "convert.single" if isDualNode(data) else "convert.dual"
 			for item in self.hideable[key]:
 				item.Show(True)
 		self.criteriaName.Value = data.get("name", "")
@@ -553,6 +557,7 @@ class CriteriaPanel(CriteriaEditorPanel):
 
 		row = 0
 		item = wx.StaticText(self, label=_("Context:"))
+		gbSizer.Add(item, pos=(row, 0))
 		gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
 		item = self.contextMacroDropDown = DropDownWithHideableChoices(self)
 		item.setChoices((
@@ -731,12 +736,21 @@ class CriteriaPanel(CriteriaEditorPanel):
 		gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
 
 		row += 1
+		## Translators: The label for a button in the Criteria Editor dialog
+		#item = wx.Button(self, label=_("Test these criteria (F5)"))
+		#item.Bind(wx.EVT_BUTTON, self.onTestCriteria)
+		#gbSizer.Add(item, pos=(row, 0), span=(1, 3), flag=wx.EXPAND)
+		vBoxSizer = wx.BoxSizer(wx.VERTICAL)
+		self.makeSettings_buttons(vBoxSizer)
+		gbSizer.Add(vBoxSizer, pos=(row, 0), span=(1, 3), flag=wx.EXPAND)
+
+		gbSizer.AddGrowableCol(2)
+
+	def makeSettings_buttons(self, vBoxSizer):
 		# Translators: The label for a button in the Criteria Editor dialog
 		item = wx.Button(self, label=_("Test these criteria (F5)"))
 		item.Bind(wx.EVT_BUTTON, self.onTestCriteria)
-		gbSizer.Add(item, pos=(row, 0), span=(1, 3))
-
-		gbSizer.AddGrowableCol(2)
+		vBoxSizer.Add(item, flag=wx.EXPAND)
 
 	def getData(self):
 		return super().getData().setdefault("selector", {})
@@ -904,7 +918,6 @@ class CriteriaPanel(CriteriaEditorPanel):
 
 	def onPanelActivated(self):
 		self.refreshContextMacroChoices()
-		# self.onContextMacroChoice(None)
 		super().onPanelActivated()
 	
 	def onTestCriteria(self, evt):
@@ -912,7 +925,20 @@ class CriteriaPanel(CriteriaEditorPanel):
 		testCriteria(self.context)
 	
 	def isValid(self):
+		self.updateData()
 		data = self.getData()
+		
+		if not data:
+			gui.messageBox(
+				# Translators: An error message on the Criteria Editor
+				message=_("You must choose at least one criteria."),
+				caption=_("Error"),
+				style=wx.OK | wx.ICON_ERROR,
+				parent=self
+			)
+			self.SetFocus()
+			return False
+		
 		roleLblExpr = self.roleCombo.Value
 		if roleLblExpr.strip():
 			if not EXPR.match(roleLblExpr):
@@ -1145,21 +1171,45 @@ class CriteriaEditorDialog(ContextualMultiCategorySettingsDialog):
 	categoryClasses = [GeneralPanel, CriteriaPanel, GesturesPanel, PropertiesPanel]
 	INITIAL_SIZE = (900, 580)
 	
-	def __init__(self, parent, *args, dualNode=False, **kwargs):
+	def __init__(
+		self,
+		parent,
+		*args,
+		dualNode=False,
+		simpleMode=True,
+		**kwargs
+	):
+		catList = self.categoryClasses = [GeneralPanel]
 		if dualNode:
-			self.categoryClasses = [
-				GeneralPanel,
-				StartCriteriaPanel,
-				EndCriteriaPanel,
-				GesturesPanel,
-				PropertiesPanel
-			]
+			catList.append(StartCriteriaPanel)
+			catList.append(EndCriteriaPanel)
+		else:
+			catList.append(CriteriaPanel)
+		self.simpleMode = simpleMode
+		if not simpleMode:
+			catList.append(GesturesPanel)
+			catList.append(PropertiesPanel)
 		super().__init__(parent, *args, **kwargs)
 	
 	def getData(self):
 		# Should always be initialized, as the Rule Editor populates it with at least
 		# the index of this Alternative Criteria Set ("criteriaIndex").
 		return self.context["data"]["criteria"]
+	
+	def initData(self, context):
+		super().initData(context)
+		reload = context.pop("CriteriaEditorFocusOnReload", None)
+		if reload is not None:
+			catList = self.catListCtrl
+			catType = reload.pop("catType")
+			if not isinstance(self.currentCategory, catType):
+				index = self.categoryClasses.index(catType)
+				catList.Select(index)
+				catList.Focus(index)  # Triggers category change
+			if reload["catList.focus"]:
+				catList.SetFocus()
+			else:
+				self.currentCategory.SetFocus()
 	
 	def makeSettings(self, settingsSizer):
 		super().makeSettings(settingsSizer)
@@ -1178,11 +1228,13 @@ class CriteriaEditorDialog(ContextualMultiCategorySettingsDialog):
 					restrictDualNodeTo = "end"
 			currCat.updateData()
 			testCriteria(self.context, restrictDualNodeTo=restrictDualNodeTo)
+		elif keycode == wx.WXK_F12 and mods == wx.MOD_NONE:
+			self.switchToFullEditor()
 			return
 		super().onCharHook(evt)
 	
 	def onConvertToDual(self, evt):
-		convertToDualNode(self.context)
+		convertToDualNode(self.getData())
 		self.EndModal(wx.ID_CONVERT)
 	
 	def onConvertToSingle(self, evt):
@@ -1194,13 +1246,31 @@ class CriteriaEditorDialog(ContextualMultiCategorySettingsDialog):
 Do you want to proceed?"""
 			),
 			# Translators: The title of a dialog on the Criteria Set editor
-			caption=_("Convert to simple zone (one set of criteria)"),
+			caption=_("Convert to simple &zone (one set of criteria)"),
 			style=wx.ICON_WARNING | wx.YES_NO | wx.NO_DEFAULT
 		) != wx.YES:
 			return
-		convertToSingleNode(self.context)
+		convertToSingleNode(self.getData())
 		self.EndModal(wx.ID_CONVERT)
 	
+	def switchToFullEditor(self):
+		if not self.simpleMode:
+			wx.Bell()
+			return
+		currCat = self.currentCategory
+		currCat.updateData()
+		self.context["CriteriaEditorFocusOnReload"] = {
+			"catType": type(currCat),
+			"catList.focus": self.catListCtrl.HasFocus(),
+		}
+		self.EndModal(wx.ID_MORE)
+	
+	def _validateAllPanels(self):
+		# Ensure all panels are loaded, hence validated
+		for catId in range(len(self.categoryClasses)):
+			self._getCategoryPanel(catId)
+		super()._validateAllPanels()
+		
 	def _saveAllPanels(self):
 		super()._saveAllPanels()
 		
@@ -1235,14 +1305,20 @@ Do you want to proceed anyway?
 
 
 def show(context, parent=None):
-	from .. import showContextualDialog
+	if parent is None:
+		parent = gui.mainFrame
+	data = context.get("data", {}).get("criteria", {})
+	simpleMode = supportsSimpleMode(data)
 	while True:
 		res = showContextualDialog(
 			CriteriaEditorDialog,
 			context,
 			parent,
-			dualNode=isDualNode(context),
+			dualNode=isDualNode(data),
+			simpleMode=simpleMode
 		)
-		if res != wx.ID_CONVERT:
+		if res == wx.ID_MORE:
+			simpleMode = False
+		elif res != wx.ID_CONVERT:
 			break
 	return res == wx.ID_OK

--- a/addon/globalPlugins/webAccess/gui/rule/editor.py
+++ b/addon/globalPlugins/webAccess/gui/rule/editor.py
@@ -31,7 +31,7 @@ __authors__ = (
 
 from abc import abstractmethod
 from collections import OrderedDict
-import config
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
@@ -41,6 +41,7 @@ import wx
 from wx.lib.expando import EVT_ETC_LAYOUT_NEEDED, ExpandoTextCtrl
 
 import addonHandler
+import config
 import controlTypes
 import gui
 from gui import guiHelper
@@ -152,6 +153,15 @@ def getSummary(context, data):
 	return "\n".join(parts)
 
 
+def supportsSimpleMode(context):
+	alternatives = context.get("data", {}).get("rule", {}).get("criteria", [])
+	if not alternatives:
+		return True
+	if len(alternatives) > 1:
+		return False
+	return True
+
+
 class RuleEditorTreeContextualPanel(RuleAwarePanelBase, TreeContextualPanel):
 	
 	def getData(self):
@@ -161,7 +171,7 @@ class RuleEditorTreeContextualPanel(RuleAwarePanelBase, TreeContextualPanel):
 		prm = self.categoryParams
 		categoryClasses = tuple(nodeInfo.categoryClass for nodeInfo in self.Parent.Parent.categoryClasses)
 		for index in (categoryClasses.index(cls) for cls in (GesturesPanel, PropertiesPanel)):
-			category = prm.tree.getXChild(prm.tree.GetRootItem(), index)
+			category = prm.tree.getXChild(prm.tree.RootItem, index)
 			self.refreshParent(category)
 
 
@@ -374,7 +384,7 @@ class AlternativesPanel(RuleEditorTreeContextualPanel):
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.indexCriteria = None
+		self.criteriaIndex = None
 
 	def makeSettings(self, settingsSizer):
 		scale = self.scale
@@ -481,6 +491,24 @@ class AlternativesPanel(RuleEditorTreeContextualPanel):
 	def getIndex(self):
 		return self.criteriaList.Selection
 
+	def isValid(self):
+		self.updateData()
+		data = self.getData()
+		if not data or any(
+			not crit.get("selector")
+			for crit in data
+		):
+			gui.messageBox(
+				# Translators: An error message on the Rule Editor
+				message=_("You must choose at least one criteria."),
+				caption=_("Error"),
+				style=wx.OK | wx.ICON_ERROR,
+				parent=self
+			)
+			return False
+		return True
+
+
 	def onCriteriaChange(self, change: Change, index: int):
 		self.updateCriteriaList(index)
 		self.refreshParent(self.categoryParams.treeNode)
@@ -500,12 +528,14 @@ class AlternativesPanel(RuleEditorTreeContextualPanel):
 			self.onCriteriaChange(Change.CREATION, index)
 
 	@guarded
-	def onEditCriteria(self, evt):
+	def onEditCriteria(self, evt, convertToDualNode=False):
 		context = self.context.copy()
 		context["new"] = False
 		listData = self.getData()
 		index = self.getIndex()
-		itemData = context["data"]["criteria"] = listData[index].copy()
+		itemData = context["data"]["criteria"] = deepcopy(listData[index])
+		if convertToDualNode:
+			criteriaEditor.convertToDualNode(itemData)
 		itemData["criteriaIndex"] = index
 		if criteriaEditor.show(context, self):
 			del listData[index]
@@ -637,8 +667,14 @@ class ChildAlternativePanel(AlternativesPanel):
 		gbSizer.Add(item, pos=(row, 0), flag=wx.EXPAND)
 		gbSizer.AddGrowableRow(row)
 		
-		row = summaryStartRow
-		col = 1
+		self.makeSettings_buttons(gbSizer, summaryStartRow, 1)
+		
+		gbSizer.AddGrowableCol(0)
+	
+	def makeSettings_buttons(self, gbSizer, row, col, full=True):
+		scale = self.scale
+		startRow = row
+		
 		gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_BUTTONS_HORIZONTAL, 0), pos=(row, col))
 		
 		col += 1
@@ -648,40 +684,42 @@ class ChildAlternativePanel(AlternativesPanel):
 		item.Bind(wx.EVT_BUTTON, self.onEditCriteria)
 		gbSizer.Add(item, pos=(row, col))
 		
-		row += 1
-		gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, col))
-		
-		row += 1
-		# Translators: Delete criteria button label
-		item = self.deleteButton = wx.Button(self, label=_("&Delete"))
-		item.Bind(wx.EVT_BUTTON, self.onDeleteCriteria)
-		gbSizer.Add(item, pos=(row, col))
+		if full:
+			row += 1
+			gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, col))
+			
+			row += 1
+			# Translators: Delete criteria button label
+			item = self.deleteButton = wx.Button(self, label=_("&Delete"))
+			item.Bind(wx.EVT_BUTTON, self.onDeleteCriteria)
+			gbSizer.Add(item, pos=(row, col))
 		
 		# Keep natural visual ordering but set last in tab order
-		row = summaryStartRow
+		row = startRow
 		# Translators: New criteria button label
 		item = self.newButton = wx.Button(self, label=_("&New..."))
-		item.Bind(wx.EVT_BUTTON, self.onNewCriteria)
+		item.Bind(
+			wx.EVT_BUTTON,
+			self.onNewCriteria if full else self.Parent.onAddAlternative,
+		)
 		gbSizer.Add(item, pos=(row, col))
 		
 		row += 1
 		gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, col))
 		
-		gbSizer.AddGrowableCol(0)
-
+	
 	def spaceIsPressedOnTreeNode(self, withShift=False):
 		self.editButton.SetFocus()
 	
 	def initData(self, context: Mapping[str, Any]) -> None:
 		super().initData(context)
-		prm = self.categoryParams
-		self.indexCriteria = prm.tree.getSelectionIndex()
-		data = self.getData()[self.indexCriteria]
+		data = self.getData()[self.getIndex()]
 		self.summaryText.Value = criteriaEditor.getSummary(self.context, data)
 		self.commentText.Value = data.get("comment", "")
 
 	def initData_alternatives(self) -> None:
-		pass
+		prm = self.categoryParams
+		self.criteriaIndex = prm.tree.getSelectionIndex()
 	
 	def updateData(self):
 		pass
@@ -690,7 +728,7 @@ class ChildAlternativePanel(AlternativesPanel):
 		self.onDeleteCriteria(None)
 
 	def getIndex(self):
-		return self.indexCriteria
+		return self.criteriaIndex
 
 	def onCriteriaChange(self, change: Change, index: int):
 		prm = self.categoryParams
@@ -841,6 +879,176 @@ class ChildPropertyPanel(
 		self.prop_reset()
 
 
+class SimpleSingleNodeCriteriaPanel(criteriaEditor.CriteriaPanel):
+	
+	def makeSettings_buttons(self, vBoxSizer):
+		super().makeSettings_buttons(vBoxSizer)
+		scale = self.scale
+		hidable = self.hidable
+		
+		items = hidable["convertToDual"] = []
+		item = vBoxSizer.AddSpacer(scale(guiHelper.SPACE_BETWEEN_BUTTONS_VERTICAL))
+		items.append(item)
+		item.Show(False)
+		# Translators: The label for a button in the Rule Editor dialog
+		item = wx.Button(self, label=_("Convert to free &zone (two sets of criteria)"))
+		item.Bind(wx.EVT_BUTTON, self.Parent.onConvertToDualNode)
+		vBoxSizer.Add(item, flag=wx.EXPAND)
+		items.append(item)
+		item.Hide()
+		
+		vBoxSizer.AddSpacer(scale(guiHelper.SPACE_BETWEEN_BUTTONS_VERTICAL))
+		# Translators: The label for a button in the Rule Editor dialog
+		item = wx.Button(self, label=_("Add alternati&ves"))
+		item.Bind(wx.EVT_BUTTON, self.Parent.onAddAlternative)
+		vBoxSizer.Add(item, flag=wx.EXPAND)
+		
+		self.Bind(wx.EVT_CHAR_HOOK, self.onCharHook)
+	
+	def getData(self):
+		return self.getRuleData().setdefault(
+			"criteria", [{}]
+		)[0].setdefault("selector", {})
+	
+	def initData(self, context):
+		super().initData(context)
+		self.Freeze()
+		show = self.getRuleType() == ruleTypes.ZONE
+		for item in self.hidable["convertToDual"]:
+			item.Show(show)
+			if isinstance(item, wx.Window):
+				# Enabled buttons can still be activated using their accelerator,
+				# even when hidden.
+				item.Enable(show)
+		self.Thaw()
+	
+	def onCharHook(self, evt):
+		keycode = evt.GetKeyCode()
+		mods = evt.GetModifiers()
+		if keycode == wx.WXK_F5 and mods == wx.MOD_NONE:
+			self.testCriteria()
+			return
+		evt.Skip()
+	
+	def onTestCriteria(self, evt):
+		# Bound to the test button by CriteriaPanel.makeSettings
+		self.testCriteria()
+	
+	def testCriteria(self):
+		self.updateData()
+		context = self.context
+		context["data"]["criteria"] = {"selector": self.getData()}
+		criteriaEditor.testCriteria(context)
+		del context["data"]["criteria"]
+	
+	def spaceIsPressedOnTreeNode(self):
+		self.contextMacroDropDown.SetFocus()
+
+
+class SimpleSummaryCriteriaPanel(ChildAlternativePanel):
+	
+	def makeSettings_buttons(self, gbSizer, row, col):
+		super().makeSettings_buttons(gbSizer, row, col, full=False)
+	
+	def initData_alternatives(self) -> None:
+		self.criteriaIndex = 0
+	
+	def onCriteriaChange(self, change: Change, index: int):
+		parent = self.Parent
+		dlg = parent.Parent.Parent
+		if change is Change.CREATION:
+			dlg.switchToFullEditor()
+		parent.switchToAppropriatePanel()
+		parent.shownPanel.initData(self.context)
+
+
+class SimpleCriteriaPanel(RuleEditorTreeContextualPanel):
+	
+	# Translators: The label for a category in the rule editor
+	title = _("Criteria")
+	
+	def makeSettings(self, settingsSizer):
+		item = self.singleNodePanel = SimpleSingleNodeCriteriaPanel(self)
+		settingsSizer.Add(item, flag=wx.EXPAND, proportion=1)
+		item.Hide()
+		
+		item = self.summaryPanel = SimpleSummaryCriteriaPanel(self)
+		settingsSizer.Add(item, flag=wx.EXPAND, proportion=1)
+		item.Hide()
+		
+		self.shownPanel = None
+	
+	def getData(self):
+		return self.getRuleData().get("criteria", [{}])[0]
+	
+	def initData(self, context):
+		super().initData(context)
+		for panel in (self.singleNodePanel, self.summaryPanel):
+			panel.initData(context)
+		self.switchToAppropriatePanel()
+	
+	def updateData(self):
+		self.shownPanel.updateData()
+	
+	def onAddAlternative(self, evt):
+		data = self.getData()
+		if not data.get("name"):
+			with wx.TextEntryDialog(
+				self,
+				# Translators: A prompt on the Rule editor
+				_("You may first provide a name for the current criteria set:"),
+				# Translators: The title of an input dialog in the Rule Editor dialog
+				_("Add alternatives"),
+			) as dlg:
+				if dlg.ShowModal() != wx.ID_OK:
+					return
+				name = dlg.Value
+				if name:
+					data["name"] = name
+		self.summaryPanel.onNewCriteria(evt)
+	
+	def onConvertToDualNode(self, evt):
+		self.summaryPanel.onEditCriteria(evt, convertToDualNode=True)
+	
+	def onPanelActivated(self):
+		super().onPanelActivated()
+		self.shownPanel.onPanelActivated()
+	
+	def isValid(self):
+		return self.shownPanel.isValid()
+	
+	def delete(self):
+		wx.Bell()
+	
+	def spaceIsPressedOnTreeNode(self):
+		self.shownPanel.spaceIsPressedOnTreeNode()
+	
+	def switchToAppropriatePanel(self):
+		data = self.getData()
+		showSummary = (
+			data.get("gestures")
+			or data.get("properties")
+			or set(data.get("selector", {}).keys()) == {"start", "end"}
+		)
+		singleNode = self.singleNodePanel
+		summary = self.summaryPanel
+		shown, hidden = (summary, singleNode) if showSummary else (singleNode, summary)
+		if shown is self.shownPanel:
+			return
+		self.shownPanel = shown
+		self.Freeze()
+		shown.Show()
+		hidden.Hide()
+		self.Thaw()
+		for child in hidden.Children:
+			if child.HasFocus():
+				if showSummary:
+					shown.SetFocus()
+				else:
+					self.Parent.tree.SetFocus()
+				break
+
+
 class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 	
 	INITIAL_SIZE = (750, 520)
@@ -856,6 +1064,27 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 		GesturesPanel,
 		PropertiesPanel,
 	]
+
+	def __init__(self, parent, *args, simpleMode=False, **kwargs):
+		self.simpleMode = simpleMode
+		if simpleMode:
+			self.categoryInitList = [
+				(GeneralPanel, 'getGeneralChildren'),
+				(SimpleCriteriaPanel, 'getSimpleCriteriaChildren'),
+				(GesturesPanel, 'getGesturesChildren'),
+				(PropertiesPanel, 'getPropertiesChildren'),
+			]
+			self.categoryClasses = [
+				GeneralPanel,
+				SimpleCriteriaPanel,
+				GesturesPanel,
+				PropertiesPanel,
+			]
+		super().__init__(parent, *args, **kwargs)
+
+	def makeSettings(self, settingsSizer):
+		super().makeSettings(settingsSizer)
+		self.Bind(wx.EVT_CHAR_HOOK, self.onCharHook)
 
 	def getGeneralChildren(self):
 		cls = RuleEditorSingleFieldChildPanel
@@ -892,6 +1121,9 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 			for data in self.getData().get("criteria", [])
 		)
 
+	def getSimpleCriteriaChildren(self):
+		return tuple()
+
 	def getGesturesChildren(self):
 		data = self.getData()
 		if data["type"] not in [ruleTypes.ACTION_TYPES]:
@@ -922,11 +1154,12 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 		return self.context["data"]["rule"]
 	
 	def initData(self, context: Mapping[str, Any]) -> None:
-		context.setdefault("data", {})
+		self.context = context
+		data = self.getData()
 		webModule = context["webModule"]
 		ruleManager = webModule.ruleManager
+		reload = context.pop("RuleEditorFocusOnReload", None)
 		if context.get("new"):
-			data = context["data"]["rule"] = {"type": ruleTypes.MARKER}
 			if ruleManager.parentZone is not None:
 				# Translators: A title of the rule editor
 				title = (_("Sub Module {} - New Rule").format(webModule.name))
@@ -936,8 +1169,15 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 			else:
 				# Translators: A title of the rule editor
 				title = (_("Web Module {} - New Rule").format(webModule.name))
+			nodeManager = ruleManager.nodeManager
+			if nodeManager:
+				node = nodeManager.getCaretNode()
+				while node is not None:
+					if node.role in formModeRoles:
+						data.setdefault("properties", {})["formMode"] = True
+						break
+					node = node.parent
 		else:
-			data = context["data"]["rule"] = context["rule"].dump()
 			if ruleManager.parentZone is not None:
 				# Translators: A title of the rule editor
 				title = (_("Sub Module {} - Edit Rule {}").format(webModule.name, data.get("name")))
@@ -960,15 +1200,60 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 				layerName = context["rule"].layer
 			title += f" ({layerName})"
 		self.SetTitle(title)
-		nodeManager = ruleManager.nodeManager
-		if nodeManager:
-			node = nodeManager.getCaretNode()
-			while node is not None:
-				if node.role in formModeRoles:
-					data.setdefault("properties", {})["formMode"] = True
-					break
-				node = node.parent
+		if reload and data.get("criteria") == [{"selector": {}}]:
+			del data["criteria"]
 		super().initData(context)
+		if reload is not None:
+			tree = self.catListCtrl
+			node = tree.RootItem
+			for index in reload["tree.path"]:
+				children = tree.getChildren(node)
+				node = children[index]
+			tree.SelectItem(node)
+			catInfos = tree.getTreeNodeInfo(node)
+			self._doCategoryChange(catInfos)
+			if reload["tree.focus"]:
+				tree.SetFocus()
+			else:
+				self.currentCategory.SetFocus()
+	
+	def onCharHook(self, evt):
+		# Bound by TreeMultiCategorySettingsDialog.makeSettings
+		keycode = evt.GetKeyCode()
+		mods = evt.GetModifiers()
+		if keycode == wx.WXK_F12 and mods == wx.MOD_NONE:
+			self.switchToFullEditor()
+			return
+		super().onCharHook(evt)
+	
+	def switchToFullEditor(self):
+		if not self.simpleMode:
+			wx.Bell()
+			return
+		self.currentCategory.updateData()
+		tree = self.catListCtrl
+		treePath = []
+		child = tree.GetSelection()
+		while child != tree.RootItem:
+			parent = tree.GetItemParent(child)
+			children = tree.getChildren(parent)
+			index = children.index(child)
+			treePath.append(index)
+			child = parent
+		treePath.reverse()
+		self.context["RuleEditorFocusOnReload"] = {
+			"tree.path": treePath,
+			"tree.focus": tree.HasFocus(),
+		}
+		self.EndModal(wx.ID_MORE)
+	
+	def _validateAllPanels(self):
+		# Ensure all first level panels are loaded, hence validated
+		tree = self.catListCtrl
+		for node in tree.getChildren(tree.RootItem):
+			info = tree.getTreeNodeInfo(node)
+			panel = self._getCategoryPanel(info)
+		super()._validateAllPanels()
 	
 	def _saveAllPanels(self):
 		super()._saveAllPanels()
@@ -1035,4 +1320,24 @@ Do you want to proceed anyway?
 
 
 def show(context, parent=None):
-	return showContextualDialog(RuleEditorDialog, context, parent) == wx.ID_OK
+	if parent is None:
+		parent = gui.mainFrame
+	data = context.setdefault("data", {})
+	if context.get("new"):
+		data["rule"] = {"type": ruleTypes.MARKER}
+	else:
+		rule = context["rule"]
+		data["rule"] = rule.dump()
+	
+	def show(simpleMode):
+		return showContextualDialog(
+			RuleEditorDialog,
+			context,
+			parent,
+			simpleMode=simpleMode,
+		)
+	
+	res = show(simpleMode=supportsSimpleMode(context))
+	if res == wx.ID_MORE:
+		res = show(simpleMode=False)
+	return res == wx.ID_OK

--- a/addon/globalPlugins/webAccess/gui/rule/manager.py
+++ b/addon/globalPlugins/webAccess/gui/rule/manager.py
@@ -78,7 +78,7 @@ lastGroupBy = "position"
 lastActiveOnly = False
 
 
-def show(context, parent):
+def show(context, parent=None):
 	showContextualDialog(Dialog, context, parent)
 
 

--- a/addon/globalPlugins/webAccess/gui/rule/properties.py
+++ b/addon/globalPlugins/webAccess/gui/rule/properties.py
@@ -301,7 +301,6 @@ class SinglePropertyEditorPanelBase(SingleFieldEditorMixin, ContextualSettingsPa
 		return self.prop.value
 	
 	def setFieldValue(self, value):
-		# @@@
 		self.prop.value = value
 	
 	def prop_reset(self):

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -21,8 +21,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2025-02-14 19:06+0100\n"
-"PO-Revision-Date: 2025-02-14 19:07+0100\n"
+"POT-Creation-Date: 2025-02-19 10:04+0100\n"
+"PO-Revision-Date: 2025-02-19 18:53+0100\n"
 "Last-Translator: Julien Cochuyt <JulienCochuyt@users.noreply.github.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -385,331 +385,341 @@ msgid "<Invalid>"
 msgstr "<Invalide>"
 
 #. Translators: The label for the list of categories in a multi category settings dialog.
-#: addon\globalPlugins\webAccess\gui\__init__.py:546
+#: addon\globalPlugins\webAccess\gui\__init__.py:552
 msgid "&Categories:"
 msgstr "&Catégories :"
 
 #. Translators: The display value of a yes/no field
 #. Translators: The displayed value of a yes/no rule property
-#: addon\globalPlugins\webAccess\gui\__init__.py:954
+#: addon\globalPlugins\webAccess\gui\__init__.py:960
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:186
 msgid "Yes"
 msgstr "Oui"
 
 #. Translators: The displayed value of a yes/no field
 #. Translators: The displayed value of a yes/no rule property
-#: addon\globalPlugins\webAccess\gui\__init__.py:957
+#: addon\globalPlugins\webAccess\gui\__init__.py:963
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:189
 msgid "No"
 msgstr "Non"
 
 #. Translators: A field label. French typically adds a space before the colon.
-#: addon\globalPlugins\webAccess\gui\__init__.py:1084
+#: addon\globalPlugins\webAccess\gui\__init__.py:1090
 #, python-brace-format
 msgid "{field}:"
 msgstr "{field} :"
 
 #. Translators: The label for a node in the category tree on a multi-category dialog
 #. Translators: A mention on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\__init__.py:1121
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:121
+#: addon\globalPlugins\webAccess\gui\__init__.py:1127
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:122
 #, python-brace-format
 msgid "{field}: {value}"
 msgstr "{field} : {value}"
 
 #. Translators: A mention on the Criteria summary report
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:178
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:560
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:179
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:565
 msgid "General - Applies to the whole web module"
 msgstr "Général - S'applique à l'ensemble du module web"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:186
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:187
 msgid "Start:"
 msgstr "Début :"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:187
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:188
 msgid "End:"
 msgstr "Fin :"
 
 #. Translators: A mention on the Criteria Summary report
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:248
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:249
 msgid "No criteria"
 msgstr "Pas de critère"
 
 #. Translators: A mention on the Criteria Summary report
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:264
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:265
 #, python-brace-format
 msgid "{indent}{field}: {value}"
 msgstr "{indent}{field} : {value}"
 
 #. Translators: The label for a section on the Criteria Summary report
 #. Translators: The label for a section on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:272
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:125
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:273
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:126
 #, python-brace-format
 msgid "{section}:"
 msgstr "{section} :"
 
 #. Translators: The title of a dialog in the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:294
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:295
 msgid "Start Criteria test"
 msgstr "Test des critères de début"
 
 #. Translators: The title of a dialog in the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:296
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:297
 msgid "End Criteria test"
 msgstr "Test des critères de fin"
 
 #. Translators: The title of a dialog in the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:302
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:303
 msgid "Combined Criteria test"
 msgstr "Test des critères combinés"
 
 #. Translators: The title of a dialog in the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:305
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:306
 msgid "Criteria test"
 msgstr "Test des critères"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:325
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:326
 msgid "Found 1 result in {:.3f} seconds."
 msgstr "Trouvé 1 résultat en {:.3f} secondes."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:327
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:328
 msgid "Found {} results in {:.3f} seconds."
 msgstr "Trouvé {} résultats en {:.3f} secondes."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:329
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:330
 msgid "No result found on the current page."
 msgstr "Aucun résultat trouvé sur la page actuelle."
 
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for the General settings panel.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:366
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:174
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:370
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:184
 msgid "General"
 msgstr "Général"
 
 #. Translator: The label for a field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:380
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:384
 msgid "Criteria Set &name:"
 msgstr "Nom du jeu de critères :"
 
 #. Translator: The label for a field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:393
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:397
 msgid "&Sequence order:"
 msgstr "Ordre de &séquence :"
 
 #. Translator: The label for a field on the Criteria editor
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:407
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:212
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:405
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:411
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:222
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:415
 msgid "Summar&y:"
 msgstr "&Résumé :"
 
 #. Translator: The label for a field on the Criteria editor
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:419
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:224
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:417
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:423
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:234
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:427
 msgid "Technical n&otes:"
 msgstr "N&otes techniques :"
 
 #. Translators: The label for a button in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:433
-msgid "Convert to free zone (two sets of criteria)"
-msgstr "Convertir en zone libre (deux jeux de critères)"
+#. Translators: The label for a button in the Rule Editor dialog
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:437
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:894
+msgid "Convert to free &zone (two sets of criteria)"
+msgstr "Convertir en &zone libre (deux jeux de critères)"
 
 #. Translators: The label for a button in the Criteria Editor dialog
-#. Translators: The title of a dialog on the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:448
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1197
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:452
 msgid "Convert to simple zone (one set of criteria)"
 msgstr "Convertir en zone simple (un seul jeu de critères)"
 
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for a category in the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:511
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:373
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:515
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:383
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:968
 msgid "Criteria"
 msgstr "Critères"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:517
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:521
 msgctxt "webAccess.ruleCriteria"
 msgid "Page &title:"
 msgstr "&Titre de page :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:519
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:523
 msgctxt "webAccess.ruleCriteria"
 msgid "Page t&ype"
 msgstr "T&ype de page"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:521
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:525
 msgctxt "webAccess.ruleCriteria"
 msgid "&Parent element"
 msgstr "Élément &parent"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:523
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:527
 msgctxt "webAccess.ruleCriteria"
 msgid "&Text:"
 msgstr "&Texte :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:525
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:529
 msgctxt "webAccess.ruleCriteria"
 msgid "&Role:"
 msgstr "&Rôle :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:527
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:531
 msgctxt "webAccess.ruleCriteria"
 msgid "T&ag:"
 msgstr "B&alise :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:529
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:533
 msgctxt "webAccess.ruleCriteria"
 msgid "&ID:"
 msgstr "&ID :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:531
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:535
 msgctxt "webAccess.ruleCriteria"
 msgid "&Class:"
 msgstr "&Classe :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:533
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:537
 msgctxt "webAccess.ruleCriteria"
 msgid "&States:"
 msgstr "État&s :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:535
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:539
 msgctxt "webAccess.ruleCriteria"
 msgid "Ima&ge source:"
 msgstr "Source de l'ima&ge :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:537
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:541
 msgctxt "webAccess.ruleCriteria"
 msgid "Document &URL:"
 msgstr "&URL du document :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:539
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:543
 msgctxt "webAccess.ruleCriteria"
 msgid "R&elative path:"
 msgstr "Ch&emin relatif :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:541
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:545
 msgctxt "webAccess.ruleCriteria"
 msgid "Inde&x:"
 msgstr "Inde&x :"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:555
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:559
 msgid "Context:"
 msgstr "Contexte :"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:562
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:567
 msgid "Page title - Applies only to pages with the given title"
 msgstr "Titre de page - S'applique uniquement aux pages portant le titre donné"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:564
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:569
 msgid "Page type - Applies only to pages with the given type"
 msgstr "Type de page - S'applique uniquement aux pages du type donné"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:566
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:571
 msgid "Parent element - Applies only within the results of another rule"
 msgstr ""
 "Élément parent - S'applique uniquement dans le cadre des résultats d'une "
 "autre règle"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:568
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:573
 msgid "Advanced"
 msgstr "Avancé"
 
 #. Translators: The label for a button in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:735
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:751
 msgid "Test these criteria (F5)"
 msgstr "Tester ces critères (F5)"
 
-#. Translators: Error message when the field doesn't meet the required syntax
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:922
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:951
-#, python-brace-format
-msgid "Syntax error in the field \"{field}\""
-msgstr "Erreur de syntaxe dans le champ \"{field}\""
+#. Translators: An error message on the Criteria Editor
+#. Translators: An error message on the Rule Editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:934
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:503
+msgid "You must choose at least one criteria."
+msgstr "Vous devez choisir au moins un critère."
 
 #. Translators: The title of a message dialog
 #. Translators: The title of an error message dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:924
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:938
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:953
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:967
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:984
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:322
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:334
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:363
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:935
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:950
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:964
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:979
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:993
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1010
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:332
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:344
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:373
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:504
 #: addon\globalPlugins\webAccess\gui\webModule\editor.py:275
 #: addon\globalPlugins\webAccess\gui\webModule\editor.py:289
 #: addon\globalPlugins\webAccess\webModuleHandler\__init__.py:357
 msgid "Error"
 msgstr "Erreur"
 
+#. Translators: Error message when the field doesn't meet the required syntax
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:948
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:977
+#, python-brace-format
+msgid "Syntax error in the field \"{field}\""
+msgstr "Erreur de syntaxe dans le champ \"{field}\""
+
 #. Translators: Error message when the field doesn't match any known identifier
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:936
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:965
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:962
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:991
 #, python-brace-format
 msgid "Unknown identifier in the field \"{field}\""
 msgstr "Identifiant inconnu dans le champ \"{field}\""
 
 #. Translators: Error message when the index is not positive
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:983
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1009
 msgid "Index, if set, must be a positive integer."
 msgstr "Index, si renseigné, doit être un nombre entier strictement positif."
 
 #. Translators: The label for a Criteria editor category.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:996
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1022
 msgid "Start Criteria"
 msgstr "Critères de début"
 
 #. Translators: The label for a Criteria editor category.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1008
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1034
 msgid "End Criteria"
 msgstr "Critères de fin"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1027
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1053
 msgid "Select a property to override"
 msgstr "Sélectionnez une propriété à surcharger"
 
 #. Translators: The label for a list on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1040
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1066
 msgid "Properties specific to this criteria set"
 msgstr "Propriétés spécifiques à cet ensemble de critères"
 
 #. Translators: A hint stating a list is empty and how to populate it on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1043
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1069
 msgid "None. Press alt+n to override a property."
 msgstr "Aucune. Appuyez sur alt+n pour remplacer une propriété."
 
 #. Translators: A column header in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1045
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1071
 msgid "Rule value"
 msgstr "Valeur de la règle"
 
 #. Translators: The label for a button on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1053
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1079
 msgid "&New"
 msgstr "&Nouveau"
 
@@ -721,10 +731,10 @@ msgstr "&Nouveau"
 #. Translator: The label for a button on the RulesManager dialog.
 #. Translators: The label for a button in the
 #. Web Modules Manager dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1063
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:448
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:656
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:749
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1089
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:458
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:693
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:787
 #: addon\globalPlugins\webAccess\gui\rule\gestures.py:144
 #: addon\globalPlugins\webAccess\gui\rule\manager.py:494
 #: addon\globalPlugins\webAccess\gui\webModule\manager.py:126
@@ -733,19 +743,19 @@ msgstr "&Supprimer"
 
 #. Avoid announcing the whole eventual control refresh
 #. Translators: Announced when resetting a property to its default value in the editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1139
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:313
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1165
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:312
 #, python-brace-format
 msgid "Reset to {value}"
 msgstr "Réinitialiser à {value}"
 
 #. Translators: The title of the Criteria Editor dialog.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1144
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1170
 msgid "WebAccess Criteria Set editor"
 msgstr "Éditeur de jeux de critères WebAccess"
 
 #. Translators: A confirmation prompt on the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1192
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1244
 msgid ""
 "This will delete your End Criteria choices.\n"
 "\n"
@@ -755,8 +765,13 @@ msgstr ""
 "\n"
 "Voulez-vous continuer ?"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1222
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:988
+#. Translators: The title of a dialog on the Criteria Set editor
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1249
+msgid "Convert to simple &zone (one set of criteria)"
+msgstr "Convertir en &zone simple (un seul jeu de critères)"
+
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1292
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1273
 msgid ""
 "The \"Transform\" property is not supported with free zones (two sets of "
 "criteria).\n"
@@ -769,72 +784,72 @@ msgstr ""
 "Voulez-vous poursuivre néanmoins ?\n"
 
 #. Translators: The title of a message dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1228
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:994
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1298
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1279
 #: addon\globalPlugins\webAccess\gui\webModule\__init__.py:86
 msgid "Warning"
 msgstr "Avertissement"
 
 #. Translators: The Label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:98
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:99
 msgid "Rule &type:"
 msgstr "&Type de règle :"
 
 #. Translators: The Label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:100
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:101
 msgid "Rule &name:"
 msgstr "&Nom de la règle :"
 
 #. Translators: A mention on the Rule summary report
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:108
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:109
 msgid "No rule type selected."
 msgstr "Aucun type de règle n'est sélectionné."
 
 #. Translators: The label for a section on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:134
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:135
 msgid "Criteria:"
 msgstr "Critères :"
 
 #. Translators: The label for a section on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:138
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:139
 msgid "Multiple criteria sets:"
 msgstr "Jeux de critères multiples :"
 
 #. Translators: The label for a section on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:143
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:144
 #, python-brace-format
 msgid "Alternative #{index} \"{name}\":"
 msgstr "Alternative #{index} \"{name}\" :"
 
 #. Translators: The label for a section on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:146
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:147
 #, python-brace-format
 msgid "Alternative #{index}:"
 msgstr "Alternative #{index} :"
 
 #. todo: change tooltip's text
 #. Translators: Tooltip for rule type choice list.
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:193
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:203
 msgid "TOOLTIP EXEMPLE"
 msgstr "EXEMPLE DE BULLE D'AIDE"
 
 #. Translators: Error message when no type is chosen before saving the rule
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:320
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:330
 msgid "You must choose a type for this rule"
 msgstr "Vous devez choisir un type pour cette règle"
 
 #. Translators: Error message when no name is entered before saving the rule
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:333
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:343
 msgid "You must choose a name for this rule"
 msgstr "Vous devez choisir un nom pour cette règle"
 
 #. Translators: Error message when another rule with the same name already exists
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:362
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:372
 msgid "There already is another rule with the same name."
 msgstr "Il existe déjà une autre règle portant le même nom."
 
 #. Translators: Label for a control in the Rule Editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:387
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:397
 msgid "&Alternatives"
 msgstr "&Alternatives"
 
@@ -842,9 +857,9 @@ msgstr "&Alternatives"
 #. Translators: New criteria button label
 #. Translators: The label for a button on the Rule Editor dialog
 #. Translators: The label for a button in the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:430
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:663
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:756
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:440
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:700
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:794
 #: addon\globalPlugins\webAccess\gui\rule\gestures.py:122
 msgid "&New..."
 msgstr "&Nouveau..."
@@ -854,8 +869,8 @@ msgstr "&Nouveau..."
 #. Translators: The label for a button in the Rule Editor dialog
 #. Translator: The label for a button on the RulesManager dialog.
 #. Translators: The label for a button in the Web Modules Manager dialog
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:439
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:647
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:449
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:683
 #: addon\globalPlugins\webAccess\gui\rule\gestures.py:133
 #: addon\globalPlugins\webAccess\gui\rule\manager.py:486
 #: addon\globalPlugins\webAccess\gui\webModule\manager.py:103
@@ -863,55 +878,70 @@ msgid "&Edit..."
 msgstr "&Modifier..."
 
 #. Translator: A confirmation prompt on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:522
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:552
 msgid "Are you sure you want to delete this alternative?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette alternative ?"
 
 #. Translator: The title for a confirmation prompt on the Rule editor
 #. Translator: The title for a confirmation prompt on the
 #. RulesManager dialog.
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:524
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:554
 #: addon\globalPlugins\webAccess\gui\rule\manager.py:743
 msgid "Confirm Deletion"
 msgstr "Confirmation d'effacement"
 
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:612
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:642
 msgid "Summar&y"
 msgstr "&Résumé"
 
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:629
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:659
 msgid "Technical n&otes"
 msgstr "N&otes techniques"
 
+#. Translators: The label for a button in the Rule Editor dialog
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:902
+msgid "Add alternati&ves"
+msgstr "Ajouter des alternati&ves"
+
+#. Translators: A prompt on the Rule editor
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:999
+msgid "You may first provide a name for the current criteria set:"
+msgstr "Vous pouvez d'abord attribuer un nom au jeu de critères existant :"
+
+#. Translators: The title of an input dialog in the Rule Editor dialog
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1001
+msgid "Add alternatives"
+msgstr "Ajouter des alternatives"
+
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:932
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1165
 msgid "Sub Module {} - New Rule"
 msgstr "Sous-module {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:935
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1168
 msgid "Root Module {} - New Rule"
 msgstr "Module racine {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:938
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1171
 msgid "Web Module {} - New Rule"
 msgstr "Module web {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:943
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1183
 msgid "Sub Module {} - Edit Rule {}"
 msgstr "Sous-module {} - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:946
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1186
 msgid "Root Module {} - Edit Rule {}"
 msgstr "Module racine - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:949
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1189
 msgid "Web Module {} - Edit Rule {}"
 msgstr "Module web {} - Modifier la règle {}"
 
@@ -1107,23 +1137,23 @@ msgid "Properties"
 msgstr "Propriétés"
 
 #. Translators: Displayed when the selected rule type doesn't support any property
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:328
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:327
 msgid "No property available for this rule type."
 msgstr "Aucune propriété n'est disponible pour ce type de règle."
 
 #. Translators: The label for a list on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:397
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:396
 msgid "&Properties"
 msgstr "&Propriétés"
 
 #. Translators: A column header on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:409
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:408
 msgctxt "webAccess.ruleEditor"
 msgid "Property"
 msgstr "Propriété"
 
 #. Translators: A column header on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:411
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:410
 msgctxt "webAccess.ruleEditor"
 msgid "Value"
 msgstr "Valeur"


### PR DESCRIPTION
WebAccess, along with capitalizing on numerous adaptation efforts of business web apps, is all about reducing the cost but also the technicity required to achieve these adaptations.
This very last aspect has been quite a bit defeated with the new, more convoluted, Multi-Criteria UI.
This PR adresses this issue as follows:
 - Rule Editor:
    - Show a simple criteria panel whenever possible
    - Switch to full edit mode using F12
 - Criteria Set Editor:
    - Hide Gestures and Properties panels whenever possible
    - Switch to full edit mode using F12
