### PR TITLE
Rule Wizard

### DIFF
--- a/addon/globalPlugins/webAccess/gui/__init__.py
+++ b/addon/globalPlugins/webAccess/gui/__init__.py
@@ -199,7 +199,8 @@ class SizeFrugalComboBox(wx.ComboBox):
 	"""
 	
 	def DoGetBestSize(self):
-		return wx.Size(0, 0)
+		size = super().DoGetBestSize()
+		return wx.Size(0, size.Height)
 
 
 class ValidationError(Exception):

--- a/addon/globalPlugins/webAccess/gui/menu.py
+++ b/addon/globalPlugins/webAccess/gui/menu.py
@@ -139,9 +139,10 @@ class Menu(wx.Menu):
 	
 	@guarded
 	def onRuleCreate(self, evt):
-		self.context["new"] = True
-		from .rule.editor import show
-		show(self.context)
+		from .rule.wizard import show
+		context = self.context.copy()
+		context["new"] = True
+		show(context)
 	
 	@guarded
 	def onRulesManager(self, evt):

--- a/addon/globalPlugins/webAccess/gui/rule/__init__.py
+++ b/addon/globalPlugins/webAccess/gui/rule/__init__.py
@@ -32,6 +32,11 @@ import addonHandler
 import gui
 from logHandler import log
 
+from ...ruleHandler import ruleTypes
+from ... import webModuleHandler
+from ...utils import updateOrDrop
+from .properties import Properties
+
 
 if sys.version_info[1] < 9:
     from typing import Mapping
@@ -87,3 +92,67 @@ Do you want to create it now?""")
 		if newName != name:
 			data["properties"]["subModule"] = newName
 	return res
+
+
+def saveRule(
+		context: Mapping[str, Any],
+		data: Mapping[str, Any],
+		parent: wx.Window
+	) -> bool:
+	if any(
+		set(critData.get("selector", {}).keys()) == {"start", "end"}
+		for critData in data.get("criteria", [])
+	) and any(
+		key == "mutation" and value
+		for key, value in data.get("properties", {}).items()
+	):
+		if gui.messageBox(
+			# Translators: A warning message on the Rule editor
+			_(
+				'''The "Transform" property is not supported with free zones (two sets of criteria).
+
+Do you want to proceed anyway?
+'''
+			),
+			# Translators: The title of a message dialog
+			caption=_("Warning"),
+			style=wx.ICON_WARNING | wx.YES_NO | wx.CANCEL | wx.NO_DEFAULT
+		) != wx.YES:
+			raise ValidationError()  # Cancels closing of the dialog
+	
+	# Remove gesture bindings and properties not supported for the selected Rule Type.
+	# This needs to be done here rather than
+	#  - upon changing the Rule Type for easier non-destructive cycle-through
+	#    the different types,
+	#  - in the panel's doSave because the Rule Type might have been changed
+	#    without even instantiating any other panel.
+	cnts = [data] + [crit for crit in data.get("criteria", tuple())]
+	for cnt in cnts:
+		if data["type"] not in ruleTypes.ACTION_TYPES or not cnt.get("gestures"):
+			cnt.pop("gestures", None)
+		updateOrDrop(
+			cnt,
+			"properties",
+			Properties(context, cnt.get("properties", {}), iterOnlyFirstMap=True).dump(),
+			{}
+		)
+	
+	mgr = context["webModule"].ruleManager
+	if context.get("new"):
+		layerName = None
+	else:
+		rule = context["rule"]
+		layerName = rule.layer
+	webModule = webModuleHandler.getEditableWebModule(mgr.webModule, layerName=layerName)
+	if not webModule:
+		raise ValidationError()  # Cancels closing of the dialog
+	if createMissingSubModule(context, data, parent) is False:
+		raise ValidationError()  # Cancels closing of the dialog
+	if context.get("new"):
+		layerName = webModule.getWritableLayer().name
+	else:
+		mgr.removeRule(rule)
+	context["rule"] = mgr.loadRule(layerName, data["name"], data)
+	webModule.getLayer(layerName, raiseIfMissing=True).dirty = True
+	if not webModuleHandler.save(webModule, layerName=layerName):
+		raise ValidationError()  # Cancels closing of the dialog

--- a/addon/globalPlugins/webAccess/gui/rule/criteriaEditor.py
+++ b/addon/globalPlugins/webAccess/gui/rule/criteriaEditor.py
@@ -323,10 +323,13 @@ def testCriteria(context, restrictDualNodeTo=None):
 	results = rule.getResults()
 	duration = time.time() - start
 	if len(results) == 1:
+		# Translators: Reported upon testing criteria
 		message = _("Found 1 result in {:.3f} seconds.".format(duration))
 	elif results:
+		# Translators: Reported upon testing criteria
 		message = _("Found {} results in {:.3f} seconds.".format(len(results), duration))
 	else:
+		# Translators: Reported upon testing criteria
 		message = _("No result found on the current page.")
 	gui.messageBox(message, caption=caption)
 
@@ -515,6 +518,12 @@ class GeneralPanel(CriteriaEditorPanel):
 
 
 class CriteriaPanel(CriteriaEditorPanel):
+	"""Criteria Panel of the Alternative Criteria Set Editor
+	
+	To accomodate with the Rule Creation Wizard which reuses this panel split on two different pages,
+	several method are split in two: "<method>_context" and "<method>_others".
+	"""
+	
 	# Translators: The label for a Criteria editor category.
 	title = _("Criteria")
 
@@ -553,13 +562,25 @@ class CriteriaPanel(CriteriaEditorPanel):
 
 	def makeSettings(self, settingsSizer):
 		scale = self.scale
+		self.hidable = {}
 		gbSizer = wx.GridBagSizer()
 		gbSizer.EmptyCellSize = (0, 0)
 		settingsSizer.Add(gbSizer, flag=wx.EXPAND, proportion=1)
-
-		hidable = self.hidable = {}
-
 		row = 0
+		row = self.makeSettings_context(gbSizer, row)
+		if row is not None:
+			row += 1
+			item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+			row += 1
+		else:
+			row = 0
+		self.makeSettings_others(gbSizer, row)
+		gbSizer.AddGrowableCol(2)
+
+	def makeSettings_context(self, gbSizer, row):
+		# This part is shown on its own page on the Rule Creation Wizard
+		scale = self.scale
+		hidable = self.hidable
 		item = wx.StaticText(self, label=_("Context:"))
 		gbSizer.Add(item, pos=(row, 0))
 		gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
@@ -580,66 +601,53 @@ class CriteriaPanel(CriteriaEditorPanel):
 		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
 
 		row += 1
-		gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		items = hidable["contextPageTitle"] = []
+		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		items.append(item)
 
 		row += 1
-		items = hidable["contextPageTitle"] = []
 		item = wx.StaticText(self, label=self.FIELDS["contextPageTitle"])
-		item.Hide()
 		items.append(item)
 		gbSizer.Add(item, pos=(row, 0))
 		item = gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
-		item.Show(False)
 		items.append(item)
 		item = self.contextPageTitleCombo = wx.ComboBox(self, size=(-1, 30))
-		item.Hide()
 		items.append(item)
 		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
-
-		row += 1
-		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
-		item.Show(False)
-		items.append(item)
 
 		row += 1
 		items = hidable["contextPageType"] = []
+		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		items.append(item)
+
+		row += 1
 		item = wx.StaticText(self, label=self.FIELDS["contextPageType"])
-		item.Hide()
 		items.append(item)
 		gbSizer.Add(item, pos=(row, 0))
 		item = gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
-		item.Show(False)
 		items.append(item)
 		item = self.contextPageTypeCombo = wx.ComboBox(self)
-		item.Hide()
 		items.append(item)
 		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
-
-		row += 1
-		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
-		item.Show(False)
-		items.append(item)
 
 		row += 1
 		items = hidable["contextParent"] = []
+		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+		items.append(item)
+
+		row += 1
 		item = wx.StaticText(self, label=self.FIELDS["contextParent"])
-		item.Hide()
 		items.append(item)
 		gbSizer.Add(item, pos=(row, 0))
 		item = gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
-		item.Show(False)
 		items.append(item)
 		item = self.contextParentCombo = wx.ComboBox(self)
-		item.Hide()
 		items.append(item)
 		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
+		return row
 
-		row += 1
-		item = gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
-		item.Show(False)
-		items.append(item)
-
-		row += 1
+	def makeSettings_others(self, gbSizer, row):
+		scale = self.scale
 		item = wx.StaticText(self, label=self.FIELDS["text"])
 		gbSizer.Add(item, pos=(row, 0))
 		item = gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
@@ -748,8 +756,6 @@ class CriteriaPanel(CriteriaEditorPanel):
 		self.makeSettings_buttons(vBoxSizer)
 		gbSizer.Add(vBoxSizer, pos=(row, 0), span=(1, 3), flag=wx.EXPAND)
 
-		gbSizer.AddGrowableCol(2)
-
 	def makeSettings_buttons(self, vBoxSizer):
 		# Translators: The label for a button in the Criteria Editor dialog
 		item = wx.Button(self, label=_("Test these criteria (F5)"))
@@ -761,14 +767,16 @@ class CriteriaPanel(CriteriaEditorPanel):
 
 	def initData(self, context):
 		super().initData(context)
+		self.initData_context(context)
+		self.initData_others(context)
+	
+	def initData_context(self, context):
 		data = self.getData()
+		self.contextPageTitleCombo.Set([context["pageTitle"]])
 		mgr = context["webModule"].ruleManager
-
-		if mgr.isReady and mgr.nodeManager:
-			node = mgr.nodeManager.getCaretNode()
-
-			self.contextPageTitleCombo.Set([context["pageTitle"]])
+		if mgr.isReady:
 			self.contextPageTypeCombo.Set(mgr.getPageTypes())
+			node = mgr.nodeManager.getCaretNode()
 			parents = []
 			for result in mgr.getResults():
 				rule = result.rule
@@ -778,7 +786,16 @@ class CriteriaPanel(CriteriaEditorPanel):
 				):
 					parents.insert(0, rule.name)
 			self.contextParentCombo.Set(parents)
-
+		self.refreshContextMacroChoices(initial=True)
+		self.contextPageTitleCombo.Value = data.get("contextPageTitle", "")
+		self.contextPageTypeCombo.Value = data.get("contextPageType", "")
+		self.contextParentCombo.Value = data.get("contextParent", "")
+	
+	def initData_others(self, context):
+		data = self.getData()
+		mgr = context["webModule"].ruleManager
+		if mgr.isReady:
+			node = mgr.nodeManager.getCaretNode()
 			textNode = node
 			node = node.parent
 			t = textNode.text
@@ -787,7 +804,7 @@ class CriteriaPanel(CriteriaEditorPanel):
 			textChoices = [t]
 			if node.previousTextNode is not None:
 				textChoices.append("<" + node.previousTextNode.text)
-
+			
 			roleChoices = []
 			tagChoices = []
 			idChoices = []
@@ -814,13 +831,7 @@ class CriteriaPanel(CriteriaEditorPanel):
 			self.statesCombo.Set(statesChoices)
 			self.srcCombo.Set(srcChoices)
 			self.urlCombo.Set(urlChoices)
-
-		self.refreshContextMacroChoices(initial=True)
-		self.onContextMacroChoice(None)
-		self.contextPageTitleCombo.Value = data.get("contextPageTitle", "")
-		self.contextPageTypeCombo.Value = data.get("contextPageType", "")
-		self.contextParentCombo.Value = data.get("contextParent", "")
-
+		
 		self.textCombo.Value = data.get("text", "")
 		value = data.get("role", "")
 		if isinstance(value, InvalidValue):
@@ -845,10 +856,17 @@ class CriteriaPanel(CriteriaEditorPanel):
 			self.indexText.Value = str(value)
 
 	def updateData(self):
+		self.updateData_context()
+		self.updateData_others()
+	
+	def updateData_context(self):
 		data = self.getData()
 		updateOrDrop(data, "contextPageTitle", self.contextPageTitleCombo.Value)
 		updateOrDrop(data, "contextPageType", self.contextPageTypeCombo.Value)
 		updateOrDrop(data, "contextParent", self.contextParentCombo.Value)
+	
+	def updateData_others(self):
+		data = self.getData()
 		updateOrDrop(data, "text", self.textCombo.Value)
 		value = self.roleCombo.Value
 		try:
@@ -920,6 +938,11 @@ class CriteriaPanel(CriteriaEditorPanel):
 		self.Thaw()
 		self._sendLayoutUpdatedEvent()
 
+	@guarded
+	def onTestCriteria(self, evt):
+		self.updateData()
+		testCriteria(self.context)
+	
 	def onPanelActivated(self):
 		self.refreshContextMacroChoices()
 		super().onPanelActivated()
@@ -929,7 +952,15 @@ class CriteriaPanel(CriteriaEditorPanel):
 		testCriteria(self.context)
 	
 	def isValid(self):
-		self.updateData()
+		self.updateData()		
+		return self.isValid_context() and self.isValid_others()
+	
+	def isValid_context(self):
+		# TODO: Check the syntax of expressions
+		return True
+	
+	def isValid_others(self):
+		# TODO: Check the syntax of expressions
 		data = self.getData()
 		
 		if not data:

--- a/addon/globalPlugins/webAccess/gui/rule/editor.py
+++ b/addon/globalPlugins/webAccess/gui/rule/editor.py
@@ -69,7 +69,7 @@ from .. import (
 	stripAccelAndColon,
 	stripAccelAndColon,
 )
-from . import createMissingSubModule, criteriaEditor, gestureBinding
+from . import criteriaEditor, gestureBinding, saveRule
 from .abc import RuleAwarePanelBase
 from .gestures import GesturesPanelBase
 from .properties import (
@@ -205,7 +205,6 @@ class GeneralPanel(RuleEditorTreeContextualPanel):
 	def makeSettings(self, settingsSizer):
 		scale = self.scale
 		gbSizer = wx.GridBagSizer()
-		#gbSizer.EmptyCellSize = (0, 0)
 		settingsSizer.Add(gbSizer, flag=wx.EXPAND, proportion=1)
 
 		row = 0
@@ -342,6 +341,7 @@ class GeneralPanel(RuleEditorTreeContextualPanel):
 		super().onPanelActivated()
 
 	def isValid(self):
+		# Beware this method is also used on the GeneralPage of the Rule Creation Wizard
 		self.updateData()
 		data = self.getData()
 		# Type is required
@@ -1209,6 +1209,7 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 		data = self.getData()
 		webModule = context["webModule"]
 		ruleManager = webModule.ruleManager
+		fromWizardPage = context.pop("fromWizardPage", None)
 		reload = context.pop("RuleEditorFocusOnReload", None)
 		if context.get("new"):
 			if ruleManager.parentZone is not None:
@@ -1231,13 +1232,13 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 		else:
 			if ruleManager.parentZone is not None:
 				# Translators: A title of the rule editor
-				title = (_("Sub Module {} - Edit Rule {}").format(webModule.name, data.get("name")))
+				title = _("Sub Module {} - Edit Rule {}").format(webModule.name, data.get("name"))
 			elif ruleManager.subModules.all():
 				# Translators: A title of the rule editor
-				title = (_("Root Module {} - Edit Rule {}").format(webModule.name, data.get("name")))
+				title = _("Root Module {} - Edit Rule {}").format(webModule.name, data.get("name"))
 			else:
 				# Translators: A title of the rule editor
-				title = (_("Web Module {} - Edit Rule {}").format(webModule.name, data.get("name")))
+				title = _("Web Module {} - Edit Rule {}").format(webModule.name, data.get("name"))
 		if config.conf["webAccess"]["devMode"]:
 			layerName = None
 			if context.get("new"):
@@ -1251,19 +1252,33 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 				layerName = context["rule"].layer
 			title += f" ({layerName})"
 		self.SetTitle(title)
-		if reload and data.get("criteria") == [{"selector": {}}]:
+		if (
+			fromWizardPage is not None or reload is not None
+		) and data.get("criteria") == [{"selector": {}}]:
 			del data["criteria"]
 		super().initData(context)
-		if reload is not None:
+		if fromWizardPage is not None or reload is not None:
+			if fromWizardPage is not None:
+				treePath = ({
+					"GeneralPage": 0,
+					"ContextPage": 1,
+					"CriteriaPage": 1,
+					"GesturesPage": 2,
+					"PropertiesPage": 3,
+				}[fromWizardPage],)
+				treeFocus = True
+			else:
+				treePath = reload["tree.path"]
+				treeFocus = reload["tree.focus"]
 			tree = self.catListCtrl
 			node = tree.RootItem
-			for index in reload["tree.path"]:
+			for index in treePath:
 				children = tree.getChildren(node)
 				node = children[index]
 			tree.SelectItem(node)
 			catInfos = tree.getTreeNodeInfo(node)
 			self._doCategoryChange(catInfos)
-			if reload["tree.focus"]:
+			if treeFocus:
 				tree.SetFocus()
 			else:
 				self.currentCategory.SetFocus()
@@ -1319,75 +1334,17 @@ class RuleEditorDialog(TreeMultiCategorySettingsDialog):
 	
 	def _saveAllPanels(self):
 		super()._saveAllPanels()
-		context = self.context
-		data = self.getData()
-		
-		if any(
-			set(critData.get("selector", {}).keys()) == {"start", "end"}
-			for critData in data.get("criteria", [])
-		) and any(
-			key == "mutation" and value
-			for key, value in data.get("properties", {}).items()
-		):
-			if gui.messageBox(
-				# Translators: A warning message on the Rule editor
-				_(
-					'''The "Transform" property is not supported with free zones (two sets of criteria).
-
-Do you want to proceed anyway?
-'''
-				),
-				# Translators: The title of a message dialog
-				caption=_("Warning"),
-				style=wx.ICON_WARNING | wx.YES_NO | wx.CANCEL | wx.NO_DEFAULT
-			) != wx.YES:
-				raise ValidationError()  # Cancels closing of the dialog
-		
-		# Remove gesture bindings and properties not supported for the selected Rule Type.
-		# This needs to be done here rather than
-		#  - upon changing the Rule Type for easier non-destructive cycle-through
-		#    the different types,
-		#  - in the panel's doSave because the Rule Type might have been changed
-		#    without even instantiating any other panel.
-		cnts = [data] + [crit for crit in data.get("criteria", tuple())]
-		for cnt in cnts:
-			if data["type"] not in ruleTypes.ACTION_TYPES or not cnt.get("gestures"):
-				cnt.pop("gestures", None)
-			updateOrDrop(
-				cnt,
-				"properties",
-				Properties(context, cnt.get("properties", {}), iterOnlyFirstMap=True).dump(),
-				{}
-			)
-		
-		mgr = context["webModule"].ruleManager
-		if context.get("new"):
-			layerName = None
-		else:
-			rule = context["rule"]
-			layerName = rule.layer
-		webModule = webModuleHandler.getEditableWebModule(mgr.webModule, layerName=layerName)
-		if not webModule:
-			raise ValidationError()  # Cancels closing of the dialog
-		if createMissingSubModule(context, data, self) is False:
-			raise ValidationError()  # Cancels closing of the dialog
-		if context.get("new"):
-			layerName = webModule.getWritableLayer().name
-		else:
-			mgr.removeRule(rule)
-		context["rule"] = mgr.loadRule(layerName, data["name"], data)
-		webModule.getLayer(layerName, raiseIfMissing=True).dirty = True
-		if not webModuleHandler.save(webModule, layerName=layerName):
-			raise ValidationError()  # Cancels closing of the dialog
+		saveRule(self.context, self.getData(), self)
 
 
 def show(context, parent=None):
 	if parent is None:
 		parent = gui.mainFrame
 	data = context.setdefault("data", {})
+	# Do not erase data eventualy coming from the Rule wizard
 	if context.get("new"):
-		data["rule"] = {"type": ruleTypes.MARKER}
-	else:
+		data.setdefault("rule", {"type": ruleTypes.MARKER})
+	elif not data.get("rule"):
 		rule = context["rule"]
 		data["rule"] = rule.dump()
 	

--- a/addon/globalPlugins/webAccess/gui/rule/manager.py
+++ b/addon/globalPlugins/webAccess/gui/rule/manager.py
@@ -776,6 +776,8 @@ class Dialog(ContextualDialog):
 				webModule=self.context["webModule"],
 				layerName=rule.layer,
 			)
+			# As a rule was deleted, all results are to be considered obsolete
+			self.disableGroupByPosition()
 			self.refreshRuleList()
 		wx.CallAfter(self.tree.SetFocus)
 	
@@ -789,20 +791,28 @@ class Dialog(ContextualDialog):
 		context["new"] = False
 		context["rule"] = rule
 		context["webModule"] = rule.ruleManager.webModule
-		from .editor import show
+		context.setdefault("data", {})["rule"] = rule.dump()
+		from . import editor
+		if editor.supportsSimpleMode(context):
+			from . import wizard
+			show = wizard.show
+		else:
+			show = editor.show
 		if show(context, parent=self):
 			rule = self.context["rule"] = context["rule"]
 			# As the rule changed, all results are to be considered obsolete
 			if not self.disableGroupByPosition():
 				self.refreshRuleList()
+		context.get("data", {}).pop("rule", None)
 		wx.CallAfter(self.tree.SetFocus)
 	
 	@guarded
 	def onRuleNew(self, evt):
 		context = self.context.copy()
 		context["new"] = True
-		from .editor import show
-		if show(context, self.Parent):
+		context.get("data", {}).pop("rule", None)
+		from .wizard import show
+		if show(context, parent=self):
 			rule = self.context["rule"] = context["rule"]
 			# As a new rule was created, all results are to be considered obsolete
 			if not self.disableGroupByPosition():

--- a/addon/globalPlugins/webAccess/gui/rule/properties.py
+++ b/addon/globalPlugins/webAccess/gui/rule/properties.py
@@ -319,8 +319,9 @@ class PropertiesPanelBase(SinglePropertyEditorPanelBase, metaclass=guiHelper.SIP
 	and `initData_properties` methods.
 	
 	Known sub-classes:
-	 - `criteriaEditor.PropertiesPanel`
+	 - `rule.criteriaEditor.PropertiesPanel`
 	 - `rule.editor.PropertiesPanel`
+	 - `rule.wizard.PropertiesPage`
 	"""
 
 	# Translators: Displayed when the selected rule type doesn't support any property
@@ -551,6 +552,7 @@ class PropertiesPanelBase(SinglePropertyEditorPanelBase, metaclass=guiHelper.SIP
 				self.prop_reset()
 				return
 		evt.Skip()
+
 	
 	@guarded
 	def onListCtrl_charHook(self, evt):

--- a/addon/globalPlugins/webAccess/gui/rule/wizard.py
+++ b/addon/globalPlugins/webAccess/gui/rule/wizard.py
@@ -1,0 +1,388 @@
+# globalPlugins/webAccess/gui/rule/wizard.py
+# -*- coding: utf-8 -*-
+
+# This file is part of Web Access for NVDA.
+# Copyright (C) 2015-2024 Accessolutions (http://accessolutions.fr)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# See the file COPYING.txt at the root of this distribution for more details.
+
+
+__version__ = "2024.02.02"
+__author__ = "Julien Cochuyt <j.cochuyt@accessolutions.fr>"
+
+
+from collections.abc import Mapping
+from typing import Any
+
+from itertools import pairwise
+import wx
+import wx.adv
+
+import addonHandler
+import api
+import gui
+from gui import guiHelper
+from logHandler import log
+import speech
+
+from ...utils import guarded, notifyError
+from ...ruleHandler import ruleTypes
+from ...ruleHandler.properties import PropertySpec
+from .. import ContextualSettingsPanel, EVT_RW_LAYOUT_NEEDED, ScalingMixin, ValidationError, stripAccel
+from .abc import RuleAwarePanelBase
+from .editor import SimpleSingleNodeCriteriaPanel
+from .criteriaEditor import testCriteria
+from .gestures import GesturesPanelBase
+from .properties import Properties, PropertiesPanelBase
+from . import editor, saveRule
+
+addonHandler.initTranslation()
+
+
+class Page(wx.adv.WizardPageSimple, ContextualSettingsPanel):
+
+	wizardPageHeaderDescription = None
+		
+	def makeSettings(self, settingsSizer):
+		scale = self.scale
+		if self.wizardPageHeaderDescription:
+			item = wx.StaticText(self, label=self.wizardPageHeaderDescription)
+			item.Wrap(scale(690))
+			settingsSizer.Add(item)
+			settingsSizer.AddSpacer(scale(guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS) * 3)
+		super().makeSettings(settingsSizer)
+		self.Bind(EVT_RW_LAYOUT_NEEDED, lambda evt: self.Layout())
+
+
+class GeneralPanel(RuleAwarePanelBase, ContextualSettingsPanel):
+	
+	def makeSettings(self, settingsSizer):
+		scale = self.scale
+		gbSizer = wx.GridBagSizer()
+		settingsSizer.Add(gbSizer, flag=wx.EXPAND, proportion=1)
+		row = 0
+		col = 0
+		item = wx.StaticText(self, label=stripAccel(editor.SHARED_LABELS["type"]))
+		gbSizer.Add(item, (row, col))
+		col += 1
+		gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), (row, col))
+		col += 1
+		item = self.ruleType = wx.Choice(
+			self,
+			choices=list(ruleTypes.ruleTypeLabels.values())
+		)
+		gbSizer.Add(item, (row, col), flag=wx.EXPAND)
+		
+		row += 1
+		gbSizer.Add(scale(0, guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS), pos=(row, 0))
+
+		row += 1
+		item = wx.StaticText(self, label=stripAccel(editor.SHARED_LABELS["name"]))
+		gbSizer.Add(item, pos=(row, 0))
+		gbSizer.Add(scale(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL, 0), pos=(row, 1))
+		item = self.ruleName = wx.TextCtrl(self)
+		gbSizer.Add(item, pos=(row, 2), flag=wx.EXPAND)
+		return row
+	
+	getData = RuleAwarePanelBase.getRuleData
+	
+	def initData(self, context):
+		super().initData(context)
+		data = self.getData()
+		self.ruleType.SetSelection(tuple(ruleTypes.ruleTypeLabels.keys()).index(self.getRuleType()))
+		self.ruleName.ChangeValue(data.get("name", ""))
+	
+	def updateData(self):
+		data = self.getData()
+		data["type"] = tuple(ruleTypes.ruleTypeLabels.keys())[self.ruleType.Selection]
+		data["name"] = self.ruleName.Value
+	
+	isValid = editor.GeneralPanel.isValid
+	
+
+class GeneralPage(Page, GeneralPanel):
+	
+	# Translators: The description for a page of the Rule wizard
+	wizardPageHeaderDescription = _(
+		"First, choose a type and name for the new Rule."
+		"\n"
+		"At any time, press F12 to leave this wizard and open the full fledged editor."
+	)
+
+
+
+class CriteriaPageBase(Page, SimpleSingleNodeCriteriaPanel):
+	
+	def makeSettings_buttons(self, vBoxSizer):
+		super(SimpleSingleNodeCriteriaPanel, self).makeSettings_buttons(vBoxSizer)
+	
+	def initData(self, context):
+		super(SimpleSingleNodeCriteriaPanel, self).initData(context)
+
+
+class ContextPage(CriteriaPageBase):
+	
+	# Translators: The description for a page of the Rule wizard
+	wizardPageHeaderDescription = _(
+		"Choose a context for the criteria of the new rule."
+		"\n\n"
+		"Contexts allow to restrict the look-up on some pages or some portion of the pages."
+		"\n\n"
+		"If unsure, keep the default \"General\" choice"
+	)
+	
+	def makeSettings_others(self, gbSizer, row):
+		return row
+	
+	def initData_others(self, context):
+		pass
+	
+	def updateData_others(self):
+		pass
+	
+	def isValid_others(self):
+		return True
+
+
+class CriteriaPage(CriteriaPageBase):
+	
+	# Translators: The description for a page of the Rule wizard
+	wizardPageHeaderDescription = _(
+		"Choose criteria for the new rule."
+		"\n\n"
+		"Each criterion corresponds to an attribute that will be looked-up on the elements all along the "
+		"branches of the document tree."
+		"\n"
+		"Suggested values are provided in the drop-down list for most of them."
+		"\n\n"
+		"Press F5 to test these criteria. Once satisfied with the result, press Enter or click Next."
+	)
+	
+	def GetNext(self):
+		page = super().GetNext()
+		# First called before initData
+		ruleType = self.Parent.context.get("data", {}).get("rule", {}).get("type")
+		if not ruleType in ruleTypes.ACTION_TYPES:
+			# Skip the Gestures page
+			page = page.GetNext()
+		return page
+	
+	def makeSettings_context(self, gbSizer, row):
+		return None
+	
+	def initData_context(self, context):
+		pass
+	
+	def updateData_context(self):
+		pass
+	
+	def isValid_context(self):
+		return True
+
+
+class GesturesPage(Page, GesturesPanelBase):
+	
+	# Translators: The description for a page of the Rule wizard
+	wizardPageHeaderDescription = _(
+		"You may associate an input gesture with an action on the result found."
+		"\n\n"
+		"Eg. define a keyboard shortcut to move to the desired location."
+	)
+	
+	def GetNext(self):
+		page = super().GetNext()
+		# First called before initData
+		ruleType = self.Parent.context.get("data", {}).get("rule", {}).get("type")
+		if not PropertySpec.forRuleType(ruleType):
+			# Skip the Properties page
+			return None
+		return page
+	
+	getData = RuleAwarePanelBase.getRuleData
+
+
+class PropertiesPage(Page, PropertiesPanelBase):
+	
+	def GetPrev(self):
+		page = super().GetPrev()
+		# First called before initData
+		ruleType = self.Parent.context.get("data", {}).get("rule", {}).get("type")
+		if not ruleType in ruleTypes.ACTION_TYPES:
+			# Skip the Gestures page
+			page = page.GetPrev()
+		return page
+	
+	def getData(self):
+		return self.context["data"]["rule"]["properties"]
+	
+	def initData_properties(self):
+		self.context["data"]["rule"].setdefault("properties", {})
+		self.props = Properties(self.context, self.getData())
+	
+	def onListCtrl_charHook(self, evt):
+		# For some reason, when the focus is on the ListCtrl, the return key
+		# does not seem to validate the wizard page. This does not happen when
+		# the same panel is shown on the editor.
+		keycode = evt.GetKeyCode()
+		mods = evt.GetModifiers()
+		if keycode in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER):
+			self.Parent.forward()
+			return
+		super().onListCtrl_charHook(evt)
+
+
+class Wizard(wx.adv.Wizard, ScalingMixin):
+	
+	pageClasses = (GeneralPage, ContextPage, CriteriaPage, GesturesPage, PropertiesPage)
+	
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.finishing = False
+		pages = self.pages = tuple(cls(self) for cls in self.pageClasses)
+		for prevPage, nextPage in pairwise(pages):
+			wx.adv.WizardPageSimple.Chain(prevPage, nextPage)
+		self.GetPageAreaSizer().Add(pages[0])
+		self.SetPageSize((self.scale(700), -1))
+		self.Bind(wx.EVT_BUTTON, self.onBackOrNext, id=wx.ID_BACKWARD)
+		self.Bind(wx.EVT_BUTTON, self.onBackOrNext, id=wx.ID_FORWARD)
+		self.Bind(wx.EVT_CHAR_HOOK, self.onCharHook)
+		self.Bind(wx.adv.EVT_WIZARD_PAGE_CHANGED, self.onPageChanged)
+		self.SetLayoutAdaptationMode(wx.DIALOG_ADAPTATION_MODE_ENABLED)
+		
+		# wxPython uses a non conventionnal French translation for this button.
+		btn = wx.FindWindowById(wx.ID_BACKWARD, self)
+		if btn.Label == "< &Retour":
+			# Avoid removing another proper translation in a language WebAccess itself
+			# would not be translated to.
+			btn.SetLabel("< &Précédent")
+	
+	def getData(self):
+		return self.context["data"]["rule"]
+	
+	def initData(self, context):
+		self.context = context
+		data = context.setdefault("data", {})
+		if context.get("new"):
+			# Translators: The title for the Rule Creation Wizard dialog
+			title = _("Rule Creation Wizard")
+			data["rule"] = {"type": ruleTypes.MARKER}
+		else:
+			# Translators: The title for the Rule Creation Wizard dialog
+			title = _("Rule Edit Wizard")
+			data["rule"] = context["rule"].dump()
+		self.SetTitle(title)
+	
+	def forward(self):
+		btn = wx.FindWindowById(wx.ID_FORWARD, self)
+		if not btn:
+			log.error("Could not find button for id=wx.ID_FORWARD")
+			return
+		cmdEvt = wx.CommandEvent(wx.wxEVT_COMMAND_BUTTON_CLICKED, wx.ID_FORWARD)
+		cmdEvt.SetEventObject(btn)
+		wx.PostEvent(self, cmdEvt)
+	
+	@guarded
+	def onBackOrNext(self, evt):
+		# Vetoing EVT_WIZARD_PAGE_CHANGING for the last page, or EVT_WIZARD_FINISHED,
+		# does not appear to be working as documented.
+		page = self.CurrentPage
+		page.updateData()
+		if evt.Id == wx.ID_BACKWARD:
+			evt.Skip()
+			return
+		assert evt.Id == wx.ID_FORWARD
+		# Using Page.Validate instead would not allow to bypass when moving backwards.
+		try:
+			if not page.isValid():
+				self.finishing = False
+				return
+		except ValidationError:
+			self.finishing = False
+			return
+		except Exception:
+			notifyError()
+			return
+		if not (page.GetNext() or self.save()):
+			return
+		evt.Skip()
+	
+	@guarded
+	def onCharHook(self, evt):
+		keycode = evt.GetKeyCode()
+		mods = evt.GetModifiers()
+		if keycode == wx.WXK_F5 and mods in (wx.MOD_NONE, wx.MOD_CONTROL):
+			self.testCriteria()
+			return
+		elif keycode == wx.WXK_F12 and mods == wx.MOD_NONE:
+			self.switchToEditor()
+			return
+		elif keycode in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER) and mods == wx.MOD_CONTROL:
+			self.finishing = True
+			self.forward()
+			return
+		evt.Skip()
+	
+	@guarded
+	def onPageChanged(self, evt):
+		page = evt.Page
+		page.initData(self.context)
+		if page.GetNext() is None:
+			btn = wx.FindWindowById(wx.ID_FORWARD, self)
+			# wxPython uses a non conventionnal French translation for this button, and sets it lately
+			# as we reach the last page.
+			if btn.Label == "&Finir":
+				# Avoid removing another proper translation in a language WebAccess itself
+				# would not be translated to.
+				btn.SetLabel("&Terminer")
+		if self.finishing:
+			self.forward()
+			return
+		# NVDA does not announce the new description on panel change, as if there was no new focus event
+		api.processPendingEvents()
+		speech.speakMessage(page.wizardPageHeaderDescription)
+	
+	@guarded
+	def save(self):
+		try:
+			saveRule(self.context, self.getData(), self)
+		except ValidationError:
+			return False
+		except Exception:
+			notifyError()
+			return False
+		return True
+	
+	@guarded
+	def switchToEditor(self):
+		self.CurrentPage.updateData()
+		context = self.context
+		context["fromWizardPage"] = type(self.CurrentPage).__name__
+		self.Hide()
+		returnCode = wx.ID_OK if editor.show(context, self) else wx.ID_CANCEL
+		self.EndModal(returnCode)  # RunWizard called ShowModal
+	
+	def testCriteria(self):
+		self.CurrentPage.updateData()
+		context = self.context
+		context["data"]["criteria"] = self.getData().get("criteria", [{}])[0]
+		testCriteria(self.context)
+		del context["data"]["criteria"]
+
+
+def show(context, parent=None):
+	wizard = Wizard(parent)
+	wizard.initData(context)
+	return wizard.RunWizard(wizard.pages[0])

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -21,8 +21,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2025-02-19 10:04+0100\n"
-"PO-Revision-Date: 2025-03-03 20:49+0100\n"
+"POT-Creation-Date: 2025-03-25 21:13+0100\n"
+"PO-Revision-Date: 2025-03-25 21:15+0100\n"
 "Last-Translator: Julien Cochuyt <JulienCochuyt@users.noreply.github.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -181,55 +181,55 @@ msgstr " - Tout autre contenu dans ces dossiers a été ignoré."
 
 #. Translators: The title of a message dialog
 #. Translators: The title of an error message dialog
-#: addon\globalPlugins\webAccess\__init__.py:267
-#: addon\globalPlugins\webAccess\__init__.py:580
+#: addon\globalPlugins\webAccess\__init__.py:268
+#: addon\globalPlugins\webAccess\__init__.py:581
 msgid "Web Access for NVDA"
 msgstr "Web Access pour NVDA"
 
 #. Translators: Input help mode message for show Web Access menu command.
-#: addon\globalPlugins\webAccess\__init__.py:297
+#: addon\globalPlugins\webAccess\__init__.py:298
 msgid "Show the Web Access menu."
 msgstr "Afficher le menu Web Access."
 
 #. Translators: Error message when attempting to show the Web Access GUI.
-#: addon\globalPlugins\webAccess\__init__.py:308
+#: addon\globalPlugins\webAccess\__init__.py:309
 msgid "You must be in a web browser to use Web Access."
 msgstr "Placez-vous dans un navigateur web pour utiliser Web Access."
 
 #. Translators: Error message when attempting to show the Web Access GUI.
-#: addon\globalPlugins\webAccess\__init__.py:312
-#: addon\globalPlugins\webAccess\__init__.py:371
+#: addon\globalPlugins\webAccess\__init__.py:313
+#: addon\globalPlugins\webAccess\__init__.py:372
 msgid "You must be on the web page to use Web Access."
 msgstr "Placez-vous sur la page web pour utiliser Web Access."
 
 #. Translators: Input help mode message for open Web Access settings command.
-#: addon\globalPlugins\webAccess\__init__.py:340
+#: addon\globalPlugins\webAccess\__init__.py:341
 msgid "Open the Web Access Settings."
 msgstr "Ouvrir les préférences Web Access."
 
 #. Translators: Input help mode message for show Web Access menu command.
-#: addon\globalPlugins\webAccess\__init__.py:359
+#: addon\globalPlugins\webAccess\__init__.py:360
 msgid "Show the element description."
 msgstr "Afficher la description de l'élément."
 
 #. Translators: Error message when attempting to show the Web Access GUI.
-#: addon\globalPlugins\webAccess\__init__.py:367
+#: addon\globalPlugins\webAccess\__init__.py:368
 msgid "The current object does not support Web Access."
 msgstr "Cet objet n'est pas pris en charge par Web Access."
 
-#: addon\globalPlugins\webAccess\__init__.py:378
+#: addon\globalPlugins\webAccess\__init__.py:379
 msgid "Toggle Web Access support."
 msgstr "Basculer le support de Web Access."
 
-#: addon\globalPlugins\webAccess\__init__.py:387
+#: addon\globalPlugins\webAccess\__init__.py:388
 msgid "Web Access support disabled."
 msgstr "Web Access désactivé."
 
-#: addon\globalPlugins\webAccess\__init__.py:390
+#: addon\globalPlugins\webAccess\__init__.py:391
 msgid "Web Access support enabled."
 msgstr "Web Access activé."
 
-#: addon\globalPlugins\webAccess\__init__.py:519
+#: addon\globalPlugins\webAccess\__init__.py:520
 msgid ""
 "This web module has been created by a newer version of Web Access for NVDA "
 "and could not be loaded:"
@@ -237,7 +237,7 @@ msgstr ""
 "Ce module web ne peut pas être utilisé car il a été créé à l'aide d'une "
 "version plus récente de Web Access pour NVDA :"
 
-#: addon\globalPlugins\webAccess\__init__.py:523
+#: addon\globalPlugins\webAccess\__init__.py:524
 msgid ""
 "These web modules have been created by a newer version of Web Access for "
 "NVDA and could not be loaded:"
@@ -245,7 +245,7 @@ msgstr ""
 "Ces modules web ne peuvent pas être utilisé car ils ont été créé à l'aide "
 "d'une version plus récente de Web Access pour NVDA :"
 
-#: addon\globalPlugins\webAccess\__init__.py:530
+#: addon\globalPlugins\webAccess\__init__.py:531
 msgid ""
 "This Python web module uses a different API version of Web Access for NVDA "
 "and could not be loaded:"
@@ -253,7 +253,7 @@ msgstr ""
 "Ce module web Python ne peut pas être utilisé car il cible une version "
 "différente de l'API de Web Access pour NVDA :"
 
-#: addon\globalPlugins\webAccess\__init__.py:534
+#: addon\globalPlugins\webAccess\__init__.py:535
 msgid ""
 "These Python web modules use a different API version of Web Access for NVDA "
 "and could not be loaded:"
@@ -261,11 +261,11 @@ msgstr ""
 "Ces modules web Python ne peuvent pas être utilisé car ils ciblent une "
 "version différente de l'API de Web Access pour NVDA :"
 
-#: addon\globalPlugins\webAccess\__init__.py:541
+#: addon\globalPlugins\webAccess\__init__.py:542
 msgid "An unexpected error occurred while attempting to load this web module:"
 msgstr "Une erreur s'est produite au chargement de ce module web :"
 
-#: addon\globalPlugins\webAccess\__init__.py:545
+#: addon\globalPlugins\webAccess\__init__.py:546
 msgid ""
 "An unexpected error occurred while attempting to load these web modules:"
 msgstr "Une erreur s'est produite au chargement de ces modules web :"
@@ -380,38 +380,38 @@ msgid "Empty"
 msgstr "Vide"
 
 #. Translator: The placeholder for an invalid value in summary reports
-#: addon\globalPlugins\webAccess\gui\__init__.py:219
+#: addon\globalPlugins\webAccess\gui\__init__.py:220
 msgid "<Invalid>"
 msgstr "<Invalide>"
 
 #. Translators: The label for the list of categories in a multi category settings dialog.
-#: addon\globalPlugins\webAccess\gui\__init__.py:552
+#: addon\globalPlugins\webAccess\gui\__init__.py:553
 msgid "&Categories:"
 msgstr "&Catégories :"
 
 #. Translators: The display value of a yes/no field
 #. Translators: The displayed value of a yes/no rule property
-#: addon\globalPlugins\webAccess\gui\__init__.py:960
+#: addon\globalPlugins\webAccess\gui\__init__.py:961
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:186
 msgid "Yes"
 msgstr "Oui"
 
 #. Translators: The displayed value of a yes/no field
 #. Translators: The displayed value of a yes/no rule property
-#: addon\globalPlugins\webAccess\gui\__init__.py:963
+#: addon\globalPlugins\webAccess\gui\__init__.py:964
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:189
 msgid "No"
 msgstr "Non"
 
 #. Translators: A field label. French typically adds a space before the colon.
-#: addon\globalPlugins\webAccess\gui\__init__.py:1090
+#: addon\globalPlugins\webAccess\gui\__init__.py:1091
 #, python-brace-format
 msgid "{field}:"
 msgstr "{field} :"
 
 #. Translators: The label for a node in the category tree on a multi-category dialog
 #. Translators: A mention on the Rule Summary report
-#: addon\globalPlugins\webAccess\gui\__init__.py:1127
+#: addon\globalPlugins\webAccess\gui\__init__.py:1128
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:122
 #, python-brace-format
 msgid "{field}: {value}"
@@ -420,7 +420,7 @@ msgstr "{field} : {value}"
 #. Translators: A mention on the Criteria summary report
 #. Translator: A selection value for the Context field on the Criteria editor
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:179
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:565
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:586
 msgid "General - Applies to the whole web module"
 msgstr "Général - S'applique à l'ensemble du module web"
 
@@ -471,195 +471,198 @@ msgstr "Test des critères combinés"
 msgid "Criteria test"
 msgstr "Test des critères"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:326
+#. Translators: Reported upon testing criteria
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:327
 msgid "Found 1 result in {:.3f} seconds."
 msgstr "Trouvé 1 résultat en {:.3f} secondes."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:328
+#. Translators: Reported upon testing criteria
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:330
 msgid "Found {} results in {:.3f} seconds."
 msgstr "Trouvé {} résultats en {:.3f} secondes."
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:330
+#. Translators: Reported upon testing criteria
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:333
 msgid "No result found on the current page."
 msgstr "Aucun résultat trouvé sur la page actuelle."
 
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for the General settings panel.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:370
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:373
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:184
 msgid "General"
 msgstr "Général"
 
 #. Translator: The label for a field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:384
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:387
 msgid "Criteria Set &name:"
 msgstr "Nom du jeu de critères :"
 
 #. Translator: The label for a field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:397
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:400
 msgid "&Sequence order:"
 msgstr "Ordre de &séquence :"
 
 #. Translator: The label for a field on the Criteria editor
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:411
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:222
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:414
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:221
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:415
 msgid "Summar&y:"
 msgstr "&Résumé :"
 
 #. Translator: The label for a field on the Criteria editor
 #. Translators: The label for a field on the Rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:423
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:234
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:426
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:233
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:427
 msgid "Technical n&otes:"
 msgstr "N&otes techniques :"
 
 #. Translators: The label for a button in the Criteria Editor dialog
 #. Translators: The label for a button in the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:437
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:440
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:894
 msgid "Convert to free &zone (two sets of criteria)"
 msgstr "Convertir en &zone libre (deux jeux de critères)"
 
 #. Translators: The label for a button in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:452
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:455
 msgid "Convert to simple zone (one set of criteria)"
 msgstr "Convertir en zone simple (un seul jeu de critères)"
 
 #. Translators: The label for a Criteria editor category.
 #. Translators: The label for a category in the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:515
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:524
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:383
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:968
 msgid "Criteria"
 msgstr "Critères"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:521
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:530
 msgctxt "webAccess.ruleCriteria"
 msgid "Page &title:"
 msgstr "&Titre de page :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:523
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:532
 msgctxt "webAccess.ruleCriteria"
 msgid "Page t&ype"
 msgstr "T&ype de page"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:525
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:534
 msgctxt "webAccess.ruleCriteria"
 msgid "&Parent element"
 msgstr "Élément &parent"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:527
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:536
 msgctxt "webAccess.ruleCriteria"
 msgid "&Text:"
 msgstr "&Texte :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:529
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:538
 msgctxt "webAccess.ruleCriteria"
 msgid "&Role:"
 msgstr "&Rôle :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:531
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:540
 msgctxt "webAccess.ruleCriteria"
 msgid "T&ag:"
-msgstr "B&alise :"
+msgstr "Ba&lise :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:533
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:542
 msgctxt "webAccess.ruleCriteria"
 msgid "&ID:"
 msgstr "&ID :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:535
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:544
 msgctxt "webAccess.ruleCriteria"
 msgid "&Class:"
 msgstr "&Classe :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:537
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:546
 msgctxt "webAccess.ruleCriteria"
 msgid "&States:"
-msgstr "État&s :"
+msgstr "Ét&ats :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:539
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:548
 msgctxt "webAccess.ruleCriteria"
 msgid "Ima&ge source:"
 msgstr "Source de l'ima&ge :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:541
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:550
 msgctxt "webAccess.ruleCriteria"
 msgid "Document &URL:"
 msgstr "&URL du document :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:543
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:552
 msgctxt "webAccess.ruleCriteria"
 msgid "R&elative path:"
 msgstr "Ch&emin relatif :"
 
 #. Translator: The label for a Rule Criteria field
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:545
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:554
 msgctxt "webAccess.ruleCriteria"
 msgid "Inde&x:"
 msgstr "Inde&x :"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:559
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:580
 msgid "Context:"
 msgstr "Contexte :"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:567
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:588
 msgid "Page title - Applies only to pages with the given title"
 msgstr "Titre de page - S'applique uniquement aux pages portant le titre donné"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:569
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:590
 msgid "Page type - Applies only to pages with the given type"
 msgstr "Type de page - S'applique uniquement aux pages du type donné"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:571
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:592
 msgid "Parent element - Applies only within the results of another rule"
 msgstr ""
 "Élément parent - S'applique uniquement dans le cadre des résultats d'une "
 "autre règle"
 
 #. Translator: A selection value for the Context field on the Criteria editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:573
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:594
 msgid "Advanced"
 msgstr "Avancé"
 
 #. Translators: The label for a button in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:751
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:757
 msgid "Test these criteria (F5)"
 msgstr "Tester ces critères (F5)"
 
 #. Translators: An error message on the Criteria Editor
 #. Translators: An error message on the Rule Editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:934
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:965
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:503
 msgid "You must choose at least one criteria."
 msgstr "Vous devez choisir au moins un critère."
 
 #. Translators: The title of a message dialog
 #. Translators: The title of an error message dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:935
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:950
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:964
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:979
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:993
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:966
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:981
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:995
 #: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1010
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1024
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1041
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:332
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:344
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:373
@@ -671,55 +674,55 @@ msgid "Error"
 msgstr "Erreur"
 
 #. Translators: Error message when the field doesn't meet the required syntax
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:948
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:977
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:979
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1008
 #, python-brace-format
 msgid "Syntax error in the field \"{field}\""
 msgstr "Erreur de syntaxe dans le champ \"{field}\""
 
 #. Translators: Error message when the field doesn't match any known identifier
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:962
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:991
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:993
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1022
 #, python-brace-format
 msgid "Unknown identifier in the field \"{field}\""
 msgstr "Identifiant inconnu dans le champ \"{field}\""
 
 #. Translators: Error message when the index is not positive
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1009
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1040
 msgid "Index, if set, must be a positive integer."
 msgstr "Index, si renseigné, doit être un nombre entier strictement positif."
 
 #. Translators: The label for a Criteria editor category.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1022
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1053
 msgid "Start Criteria"
 msgstr "Critères de début"
 
 #. Translators: The label for a Criteria editor category.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1034
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1065
 msgid "End Criteria"
 msgstr "Critères de fin"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1053
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1084
 msgid "Select a property to override"
 msgstr "Sélectionnez une propriété à surcharger"
 
 #. Translators: The label for a list on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1066
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1097
 msgid "Properties specific to this criteria set"
 msgstr "Propriétés spécifiques à cet ensemble de critères"
 
 #. Translators: A hint stating a list is empty and how to populate it on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1069
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1100
 msgid "None. Press alt+n to override a property."
 msgstr "Aucune. Appuyez sur alt+n pour remplacer une propriété."
 
 #. Translators: A column header in the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1071
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1102
 msgid "Rule value"
 msgstr "Valeur de la règle"
 
 #. Translators: The label for a button on the Criteria Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1079
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1110
 msgid "&New"
 msgstr "&Nouveau"
 
@@ -731,7 +734,7 @@ msgstr "&Nouveau"
 #. Translator: The label for a button on the RulesManager dialog.
 #. Translators: The label for a button in the
 #. Web Modules Manager dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1089
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1120
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:458
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:693
 #: addon\globalPlugins\webAccess\gui\rule\editor.py:787
@@ -743,19 +746,19 @@ msgstr "&Supprimer"
 
 #. Avoid announcing the whole eventual control refresh
 #. Translators: Announced when resetting a property to its default value in the editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1165
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1196
 #: addon\globalPlugins\webAccess\gui\rule\properties.py:312
 #, python-brace-format
 msgid "Reset to {value}"
 msgstr "Réinitialiser à {value}"
 
 #. Translators: The title of the Criteria Editor dialog.
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1170
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1201
 msgid "WebAccess Criteria Set editor"
 msgstr "Éditeur de jeux de critères WebAccess"
 
 #. Translators: A confirmation prompt on the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1244
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1275
 msgid ""
 "This will delete your End Criteria choices.\n"
 "\n"
@@ -766,12 +769,12 @@ msgstr ""
 "Voulez-vous continuer ?"
 
 #. Translators: The title of a dialog on the Criteria Set editor
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1249
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1280
 msgid "Convert to simple &zone (one set of criteria)"
 msgstr "Convertir en &zone simple (un seul jeu de critères)"
 
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1292
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1273
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1323
+#: addon\globalPlugins\webAccess\gui\rule\__init__.py:112
 msgid ""
 "The \"Transform\" property is not supported with free zones (two sets of "
 "criteria).\n"
@@ -784,8 +787,8 @@ msgstr ""
 "Voulez-vous poursuivre néanmoins ?\n"
 
 #. Translators: The title of a message dialog
-#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1298
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1279
+#: addon\globalPlugins\webAccess\gui\rule\criteriaEditor.py:1329
+#: addon\globalPlugins\webAccess\gui\rule\__init__.py:118
 #: addon\globalPlugins\webAccess\gui\webModule\__init__.py:86
 msgid "Warning"
 msgstr "Avertissement"
@@ -829,7 +832,7 @@ msgstr "Alternative #{index} :"
 
 #. todo: change tooltip's text
 #. Translators: Tooltip for rule type choice list.
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:203
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:202
 msgid "TOOLTIP EXEMPLE"
 msgstr "EXEMPLE DE BULLE D'AIDE"
 
@@ -916,32 +919,32 @@ msgid "Add alternatives"
 msgstr "Ajouter des alternatives"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1165
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1166
 msgid "Sub Module {} - New Rule"
 msgstr "Sous-module {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1168
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1169
 msgid "Root Module {} - New Rule"
 msgstr "Module racine {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1171
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1172
 msgid "Web Module {} - New Rule"
 msgstr "Module web {} - Nouvelle règle"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1183
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1184
 msgid "Sub Module {} - Edit Rule {}"
 msgstr "Sous-module {} - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1186
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1187
 msgid "Root Module {} - Edit Rule {}"
 msgstr "Module racine - Modifier la règle {}"
 
 #. Translators: A title of the rule editor
-#: addon\globalPlugins\webAccess\gui\rule\editor.py:1189
+#: addon\globalPlugins\webAccess\gui\rule\editor.py:1190
 msgid "Web Module {} - Edit Rule {}"
 msgstr "Module web {} - Modifier la règle {}"
 
@@ -1137,29 +1140,95 @@ msgid "Properties"
 msgstr "Propriétés"
 
 #. Translators: Displayed when the selected rule type doesn't support any property
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:327
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:328
 msgid "No property available for this rule type."
 msgstr "Aucune propriété n'est disponible pour ce type de règle."
 
 #. Translators: The label for a list on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:396
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:397
 msgid "&Properties"
 msgstr "&Propriétés"
 
 #. Translators: A column header on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:408
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:409
 msgctxt "webAccess.ruleEditor"
 msgid "Property"
 msgstr "Propriété"
 
 #. Translators: A column header on the Rule Editor dialog
-#: addon\globalPlugins\webAccess\gui\rule\properties.py:410
+#: addon\globalPlugins\webAccess\gui\rule\properties.py:411
 msgctxt "webAccess.ruleEditor"
 msgid "Value"
 msgstr "Valeur"
 
+#: addon\globalPlugins\webAccess\gui\rule\wizard.py:120
+msgid ""
+"First, choose a type and name for the new Rule.\n"
+"At any time, press F12 to leave this wizard and open the full fledged editor."
+msgstr ""
+"D'abord, choisissez un type et un nom pour la nouvelle règle.\n"
+"À tout moment, appuyez sur F12 pour quitter cet assistant et ouvrir "
+"l'éditeur complet."
+
+#: addon\globalPlugins\webAccess\gui\rule\wizard.py:140
+msgid ""
+"Choose a context for the criteria of the new rule.\n"
+"\n"
+"Contexts allow to restrict the look-up on some pages or some portion of the "
+"pages.\n"
+"\n"
+"If unsure, keep the default \"General\" choice"
+msgstr ""
+"Les contextes permettent de restreindre la recherche à certaines pages ou à "
+"certaines portions des pages.\n"
+"\n"
+"En cas de doute, conservez le choix par défaut \"Général\"."
+
+#: addon\globalPlugins\webAccess\gui\rule\wizard.py:164
+msgid ""
+"Choose criteria for the new rule.\n"
+"\n"
+"Each criterion corresponds to an attribute that will be looked-up on the "
+"elements all along the branches of the document tree.\n"
+"Suggested values are provided in the drop-down list for most of them.\n"
+"\n"
+"Press F5 to test these criteria. Once satisfied with the result, press Enter "
+"or click Next."
+msgstr ""
+"Choisissez les critères pour la nouvelle règle.\n"
+"\n"
+"Chaque critère correspond à un attribut qui sera recherché le long des "
+"branches de l'arbre du document.\n"
+"Des suggestions de valeurs sont fournies dans la liste déroulante pour la "
+"plupart d'entre eux.\n"
+"\n"
+"Appuyez sur F5 pour tester ces critères. Une fois satisfait du résultat, "
+"appuyez sur Entrée ou cliquez sur Suivant."
+
+#: addon\globalPlugins\webAccess\gui\rule\wizard.py:200
+msgid ""
+"You may associate an input gesture with an action on the result found.\n"
+"\n"
+"Eg. define a keyboard shortcut to move to the desired location."
+msgstr ""
+"Vous pouvez associer des gestes de commande à des actions ciblant les "
+"résultats.\n"
+"\n"
+"Par exemple, définir un raccourci clavier pour se déplacer vers "
+"l'emplacement souhaité."
+
+#. Translators: The title for the Rule Creation Wizard dialog
+#: addon\globalPlugins\webAccess\gui\rule\wizard.py:280
+msgid "Rule Creation Wizard"
+msgstr "Assistant nouvelle règle"
+
+#. Translators: The title for the Rule Creation Wizard dialog
+#: addon\globalPlugins\webAccess\gui\rule\wizard.py:284
+msgid "Rule Edit Wizard"
+msgstr "Assistant modification de règle"
+
 #. Translators: A prompt for creation of a missing SubModule
-#: addon\globalPlugins\webAccess\gui\rule\__init__.py:69
+#: addon\globalPlugins\webAccess\gui\rule\__init__.py:74
 #, python-brace-format
 msgid ""
 "SubModule {name} could not be found.\n"


### PR DESCRIPTION
Fixes #41

This first implementation mostly presents the main panels of the Rule Editor in simple mode.
Hitting F12 brings up the editor pre-filled with the data already entered on the wizard, with the corresponding category panel focused.
Hitting control+enter finishes the wizard, despite its lack for a finish button before the last page.
The wizard is invoked by the "New Rule" WebAccess Menu entry as well as the new and edit buttons on the Rule Manager.

The Properties page currently lacks a header prompt. Suggestions are welcome!