### PR TITLE
fix(ruleHandler): Preserve full text in search criteria

### DIFF
--- a/addon/globalPlugins/webAccess/ruleHandler/__init__.py
+++ b/addon/globalPlugins/webAccess/ruleHandler/__init__.py
@@ -1831,7 +1831,7 @@ def getSimpleSearchKwargs(criteria, raiseOnUnsupported=False):
 			if expr[0] == "<":
 				kwargs["in_prevText"] = expr[1:]
 				continue
-			kwargs["in_text"] = expr[1:]
+			kwargs["in_text"] = expr
 			continue
 		if prop == "className":
 			# For "className", both space and ampersand are treated as "and" operator


### PR DESCRIPTION
The first character of the text criterion was incorrectly stripped
when building search kwargs. Only the '<' prefix for prevText search
should be removed.

Fixes #59
